### PR TITLE
Add usage history command

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -40,3 +40,6 @@ export const isDuplicatePendingFx = createEffect(
     return db.isDuplicatePending(params.telegram_id, params.target_username);
   }
 );
+
+// Fetch recent history of downloads for admin reporting
+export const getRecentHistoryFx = createEffect((limit: number) => db.getRecentHistory(limit));


### PR DESCRIPTION
## Summary
- expand queue cleanup window to 30 days
- expose `getRecentHistory()` in DB layer
- add corresponding effect
- implement `/history` admin command and document in help text

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6844aaf55b5883268a2b46414fdf3e82