### PR TITLE
Add profile monitor management

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,7 @@ Once the bot and userbot are up and running, the Telegram Story Viewer is ready 
 
 <h2>🚀 Usage</h2>
 Just send a message to the bot with the desired Telegram username, phone number, or the direct link to story. Wait for the bot to retrieve and deliver the stories back to you
+
+### Monitoring Profiles
+
+Premium users can monitor up to **5** profiles for new stories. The bot checks every **6 hours** and will send you any new active stories found. Use `/monitor <@username>` to add a profile and `/unmonitor <@username>` to remove one. Send `/monitor` or `/unmonitor` without arguments to see your current list.

--- a/src/services/monitor-service.ts
+++ b/src/services/monitor-service.ts
@@ -2,14 +2,27 @@ import { getAllStoriesFx } from 'controllers/get-stories';
 import { sendActiveStories } from 'controllers/send-active-stories';
 import { mapStories } from 'controllers/download-stories';
 import { isUserPremium } from './premium-service';
-import { addMonitor, countMonitors, listMonitors, getDueMonitors, updateMonitorChecked, MonitorRow } from '../db';
+import {
+  addMonitor,
+  removeMonitor,
+  countMonitors,
+  listMonitors,
+  getDueMonitors,
+  updateMonitorChecked,
+  MonitorRow,
+} from '../db';
 import { UserInfo } from 'types';
 import { BOT_ADMIN_ID } from 'config/env-config';
 
-const CHECK_INTERVAL_HOURS = 6;
+export const CHECK_INTERVAL_HOURS = 6;
+export const MAX_MONITORS_PER_USER = 5;
 
 export function addProfileMonitor(userId: string, username: string): void {
   addMonitor(userId, username);
+}
+
+export function removeProfileMonitor(userId: string, username: string): void {
+  removeMonitor(userId, username);
 }
 
 export function userMonitorCount(userId: string): number {


### PR DESCRIPTION
## Summary
- support unmonitoring profiles
- show monitor/unmonitor commands in help and bot menu
- include polling interval and limit in /monitor output
- document monitoring in README

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6844b162b10883269d19d76a5c0a45a9