### PR TITLE
Implement flexible monitor limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ Just send a message to the bot with the desired Telegram username, phone number,
 
 ### Monitoring Profiles
 
-Premium users can monitor up to **5** profiles for new stories. The bot checks every **6 hours** and will send you any new active stories found. Use `/monitor <@username>` to add a profile and `/unmonitor <@username>` to remove one. Send `/monitor` or `/unmonitor` without arguments to see your current list.
+Free users cannot monitor profiles. Premium users can monitor up to **5** profiles for new stories, while admins have no limit. The bot checks every **6 hours** and will send you any new active stories found. Use `/monitor <@username>` to add a profile and `/unmonitor <@username>` to remove one. Send `/monitor` or `/unmonitor` without arguments to see your current list.


### PR DESCRIPTION
## Summary
- add dedicated active story fetcher for monitor service
- show premium monitor limits in `/help` and `/premium`
- display unlimited text for admin monitor list
- update docs around monitoring

## Testing
- `yarn lint` *(fails: ESLint config missing)*
- `yarn build` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6844b51721c083269672d1a76b05d78e