### PR TITLE
Update monitor help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ Just send a message to the bot with the desired Telegram username, phone number,
 
 ### Monitoring Profiles
 
-Free users cannot monitor profiles. Premium users can monitor up to **5** profiles for new stories, while admins have no limit. Each monitored account is checked every **6 hours** on its own schedule. Use `/monitor <@username|+123456789>` to add a profile by username or phone number, and `/unmonitor <@username>` to remove one. Send `/monitor` or `/unmonitor` without arguments to see your current list.
+Free users cannot monitor profiles. Premium users can monitor up to **5** profiles for new stories, while admins have no limit. Each monitored account is checked every **6 hours** on its own schedule. Use `/monitor <@username|+19875551234>` to add a profile by username or phone number (digits only, no hyphens), and `/unmonitor <@username>` to remove one. Send `/monitor` or `/unmonitor` without arguments to see your current list.

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ bot.start(async (ctx) => {
   await ctx.reply(
     "🔗 Please send one of the following:\n\n" +
       "*Username with '@' symbol:*\n`@durov`\n\n" +
-      "*Phone number with '+' symbol:*\n`+15551234567`\n\n" +
+      "*Phone number with '+' symbol:*\n`+19875551234`\n\n" +
       '*Direct link to a story:*\n`https://t.me/durov/s/1`',
     { ...extraOptions, parse_mode: 'Markdown' }
   );
@@ -77,7 +77,7 @@ bot.command('help', async (ctx) => {
     finalHelpText +=
       '\n*Premium Commands:*\n' +
       `\`/monitor\` - Monitor a profile for new stories (${limitDesc})\n` +
-      '               (use @username or +phone)\n' +
+      '               (use @username or +phone like +19875551234, no hyphens)\n' +
       '`/unmonitor` - Stop monitoring a profile\n';
   }
 
@@ -123,7 +123,7 @@ bot.command('monitor', async (ctx) => {
         ? 'You can monitor an unlimited number of profiles. '
         : `You can monitor up to ${MAX_MONITORS_PER_USER} profiles. `;
       return ctx.reply(
-        `Usage: /monitor <@username|+123456789>\n` +
+        `Usage: /monitor <@username|+19875551234>\n` +
           limitMsg +
           `Checks run every ${CHECK_INTERVAL_HOURS}h.`
       );
@@ -356,7 +356,7 @@ bot.on('text', async (ctx) => {
     return;
   }
 
-  await ctx.reply('🚫 Invalid input. Send `@username`, `+123456789` or a story link. Type /help for more info.');
+  await ctx.reply('🚫 Invalid input. Send `@username`, `+19875551234` or a story link. Type /help for more info.');
 });
 
 


### PR DESCRIPTION
## Summary
- clarify usage of `/monitor` in the help message
- document phone number format in README
- use consistent sample phone number across messages

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6844d065095c8326bfb349309e59e48d