### PR TITLE
Remove exposed port from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ RUN yarn build
 # Set up environment and permissions
 # =========================================================================
 ENV NODE_ENV=production
-EXPOSE 33444
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## Summary
- remove EXPOSE from Dockerfile

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `npm run build`
- `docker build -t telegram-bot-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6844ddec33248326a8483773eb0601e6