### PR TITLE
Remove EXPOSE from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ RUN yarn build
 # Set up environment and permissions
 # =========================================================================
 ENV NODE_ENV=production
-EXPOSE 33444
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## Summary
- delete the `EXPOSE 33444` instruction from Dockerfile

## Testing
- `yarn lint` *(fails: couldn't find eslint.config)*
- `yarn build`
- `docker build` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6844de6b61c483269c9d4791adcdc682