### PR TITLE
Add persistent payment check scheduling

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -43,3 +43,26 @@ export const isDuplicatePendingFx = createEffect(
 
 // Fetch recent history of downloads for admin reporting
 export const getRecentHistoryFx = createEffect((limit: number) => db.getRecentHistory(limit));
+
+// Payment check effects
+export const addPaymentCheckFx = createEffect(
+  async (params: {
+    user_id: string;
+    invoice_id: number;
+    from_address: string;
+    next_check: number;
+    check_start: number;
+  }) => db.addPaymentCheck(params.user_id, params.invoice_id, params.from_address, params.next_check, params.check_start),
+);
+
+export const updatePaymentCheckNextFx = createEffect((params: { id: number; next_check: number }) =>
+  db.updatePaymentCheckNext(params.id, params.next_check),
+);
+
+export const updatePaymentCheckInvoiceFx = createEffect((params: { id: number; invoice_id: number }) =>
+  db.updatePaymentCheckInvoice(params.id, params.invoice_id),
+);
+
+export const removePaymentCheckFx = createEffect((id: number) => db.removePaymentCheck(id));
+
+export const listPaymentChecksFx = createEffect(() => db.listPaymentChecks());

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import {
   CHECK_INTERVAL_HOURS,
   MAX_MONITORS_PER_USER,
 } from './services/monitor-service';
-import { createInvoice, schedulePaymentCheck } from './services/btc-payment';
+import { createInvoice, schedulePaymentCheck, restorePaymentChecks } from './services/btc-payment';
 import { UserInfo } from 'types';
 
 export const bot = new Telegraf<IContextBot>(BOT_TOKEN!);
@@ -389,6 +389,7 @@ bot.on('text', async (ctx) => {
     upgradeState.checkStart = Date.now();
     await ctx.reply('Address received. Monitoring for payment...');
     schedulePaymentCheck(ctx);
+    ctx.session.upgrade = undefined;
     return;
   }
 
@@ -428,6 +429,7 @@ async function startApp() {
   console.log('[App] Kicking off initial queue processing...');
   processQueue();
   startMonitorLoop();
+  restorePaymentChecks();
   await bot.telegram.setMyCommands([
     { command: 'start', description: 'Show usage instructions' },
     { command: 'help', description: 'Show help message' },


### PR DESCRIPTION
## Summary
- persist pending payment checks in SQLite
- reschedule outstanding payment timers on startup
- store/update/remove payment check records as invoices are processed

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6844ec2849b4832693bf11e2f7252ddf