### PR TITLE
Persist BTC payment timers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,10 +29,16 @@ import {
   CHECK_INTERVAL_HOURS,
   MAX_MONITORS_PER_USER,
 } from './services/monitor-service';
-import { createInvoice, schedulePaymentCheck } from './services/btc-payment';
+import {
+  createInvoice,
+  schedulePaymentCheck,
+  resumePendingChecks,
+  setBotInstance,
+} from './services/btc-payment';
 import { UserInfo } from 'types';
 
 export const bot = new Telegraf<IContextBot>(BOT_TOKEN!);
+setBotInstance(bot);
 const RESTART_COMMAND = 'restart';
 const extraOptions: any = { link_preview_options: { is_disabled: true } };
 
@@ -429,6 +435,7 @@ async function startApp() {
   console.log('[App] Kicking off initial queue processing...');
   processQueue();
   startMonitorLoop();
+  resumePendingChecks();
   await bot.telegram.setMyCommands([
     { command: 'start', description: 'Show usage instructions' },
     { command: 'help', description: 'Show help message' },


### PR DESCRIPTION
## Summary
- persist pending BTC payment checks in new `payment_checks` table
- track timers in `btc-payment` and reload them on startup
- wire startup to resume scheduled payment checks
- inject bot instance into payment service

## Testing
- `yarn test`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6844ed90a81483269c4f9b3a99ca005b