### PR TITLE
Improve monitor command messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Just send a message to the bot with the desired Telegram username, phone number,
 
 ### Monitoring Profiles
 
-Free users cannot monitor profiles. Premium users can monitor up to **5** profiles for new stories, while admins have no limit. Each monitored account is checked every **6 hours** on its own schedule. Use `/monitor <@username|+19875551234>` to add a profile by username or phone number (digits only, no hyphens), and `/unmonitor <@username>` to remove one. Send `/monitor` or `/unmonitor` without arguments to see your current list.
+Free users cannot monitor profiles. Premium users can monitor up to **5** profiles for new stories, while admins have no limit. Each monitored account is checked every **6 hours** on its own schedule. Use `/monitor <@username|+19875551234>` to add a profile by username or phone number (digits only, no hyphens), and `/unmonitor <@username>` to remove one. After adding a monitor, the bot tells you how many slots you have left. Send `/monitor` or `/unmonitor` without arguments to see your current list.
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,13 +99,10 @@ bot.command('help', async (ctx) => {
   const isAdmin = ctx.from.id === BOT_ADMIN_ID;
   const isPremium = isUserPremium(String(ctx.from.id));
   if (isPremium || isAdmin) {
-    const limitDesc = isAdmin
-      ? 'unlimited'
-      : `up to ${MAX_MONITORS_PER_USER}`;
     finalHelpText +=
       '\n*Premium Commands:*\n' +
-      `\`/monitor\` - Monitor a profile for new stories (${limitDesc})\n` +
-      '               (use @username or a phone number like +19875551234, no hyphens)\n' +
+      '`/monitor` - Monitor a profile for new stories\n' +
+      '  Use @username or a phone number like +19875551234 (no hyphens)\n' +
       '`/unmonitor` - Stop monitoring a profile\n';
   }
 
@@ -191,7 +188,18 @@ bot.command('monitor', async (ctx) => {
     }
   }
   addProfileMonitor(userId, username);
-  await ctx.reply(`✅ Now monitoring ${input} for active stories.`);
+  const currentCount = userMonitorCount(userId);
+  const remainingText = isAdmin
+    ? 'You can monitor unlimited profiles.'
+    : `You have ${Math.max(
+        MAX_MONITORS_PER_USER - currentCount,
+        0
+      )} monitor${
+        MAX_MONITORS_PER_USER - currentCount === 1 ? '' : 's'
+      } left.`;
+  await ctx.reply(
+    `✅ Now monitoring ${input} for active stories. ${remainingText}`
+  );
 });
 
 bot.command('unmonitor', async (ctx) => {


### PR DESCRIPTION
## Summary
- tidy the `/monitor` help message
- show remaining monitor slots after adding one
- document new behaviour in README

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config file)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6844f1e7ba5c8326bcd6f642b1eab6a6