### PR TITLE
Fix /upgrade with BTC handler and tests

### DIFF
--- a/__tests__/upgrade-command.test.ts
+++ b/__tests__/upgrade-command.test.ts
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+// Mock env-config to avoid requiring actual environment variables
+jest.mock('../src/config/env-config', () => ({ BTC_WALLET_ADDRESS: 'addr' }));
+
+import { handleUpgrade } from '../src/controllers/upgrade';
+import { IContextBot } from '../src/config/context-interface';
+import * as btc from '../src/services/btc-payment';
+import { PaymentRow } from '../src/db';
+
+const fakeInvoice = {
+  id: 1,
+  user_id: '123',
+  invoice_amount: 0.0001,
+  user_address: 'addr',
+  paid_amount: 0,
+  expires_at: 0,
+} as PaymentRow;
+
+describe('upgrade command', () => {
+  test('creates invoice and stores session', async () => {
+    const spy = jest.spyOn(btc, 'createInvoice').mockResolvedValue(fakeInvoice);
+    const replies: any[] = [];
+    const ctx = {
+      from: { id: 123 },
+      session: {} as any,
+      reply: jest.fn((...args) => { replies.push(args); }),
+    } as unknown as IContextBot;
+
+    await handleUpgrade(ctx);
+
+    expect(spy).toHaveBeenCalledWith('123', 5);
+    expect(ctx.session.upgrade?.invoice).toBe(fakeInvoice);
+    expect(replies.length).toBe(1);
+    expect(replies[0][0]).toContain('addr');
+    spy.mockRestore();
+  });
+});

--- a/src/controllers/upgrade.ts
+++ b/src/controllers/upgrade.ts
@@ -1,0 +1,26 @@
+import { IContextBot } from 'config/context-interface';
+import { createInvoice } from 'services/btc-payment';
+
+/**
+ * Handle the `/upgrade` command. Creates a BTC invoice and stores
+ * the invoice information in the session so the payment can be
+ * tracked later.
+ */
+export async function handleUpgrade(ctx: IContextBot): Promise<void> {
+  try {
+    const invoice = await createInvoice(String(ctx.from!.id), 5);
+    ctx.session.upgrade = {
+      invoice,
+      awaitingAddressUntil: Date.now() + 60 * 60 * 1000,
+    };
+    await ctx.reply(
+      `Send *${invoice.invoice_amount.toFixed(8)} BTC* (~$5) to the following address:\n` +
+        `\`${invoice.user_address}\`\n` +
+        'Reply with the address you will pay from within one hour.',
+      { parse_mode: 'Markdown' },
+    );
+  } catch (e) {
+    console.error('upgrade cmd error', e);
+    await ctx.reply('Failed to create invoice. Please try again later.');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,11 @@ import {
   MAX_MONITORS_PER_USER,
 } from './services/monitor-service';
 import {
-  createInvoice,
   schedulePaymentCheck,
   resumePendingChecks,
   setBotInstance,
 } from './services/btc-payment';
+import { handleUpgrade } from 'controllers/upgrade';
 import { UserInfo } from 'types';
 
 export const bot = new Telegraf<IContextBot>(BOT_TOKEN!);
@@ -138,21 +138,7 @@ bot.command('premium', async (ctx) => {
 });
 
 bot.command('upgrade', async (ctx) => {
-  try {
-    const invoice = await createInvoice(String(ctx.from.id), 5);
-    ctx.session.upgrade = {
-      invoice,
-      awaitingAddressUntil: Date.now() + 60 * 60 * 1000,
-    };
-    await ctx.reply(
-      `Send *${invoice.invoice_amount.toFixed(8)} BTC* (~$5) to the following address:\n\`${invoice.user_address}\`\n` +
-        'Reply with the address you will pay from within one hour.',
-      { parse_mode: 'Markdown' }
-    );
-  } catch (e) {
-    console.error('upgrade cmd error', e);
-    await ctx.reply('Failed to create invoice. Please try again later.');
-  }
+  await handleUpgrade(ctx);
 });
 
 bot.command('monitor', async (ctx) => {


### PR DESCRIPTION
## Summary
- move upgrade logic to a dedicated handler using BTC payments
- wire the bot to the new upgrade handler
- test upgrade handler creates a BTC invoice

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6844f2d722508326a76f8824a6c746c4