### PR TITLE
Fix userbot auth errors causing profile fetch failures

### DIFF
--- a/src/config/userbot.ts
+++ b/src/config/userbot.ts
@@ -14,6 +14,22 @@ export class Userbot {
   private static initPromise: Promise<TelegramClient> | null = null;
 
   /**
+   * Force reinitialization of the Telegram client. Useful when the session
+   * becomes invalid (e.g. AUTH_KEY_UNREGISTERED) and we need a fresh login.
+   */
+  public static async reset(): Promise<void> {
+    if (Userbot.client) {
+      try {
+        await Userbot.client.disconnect();
+      } catch (e) {
+        console.error('[Userbot] Error while disconnecting:', e);
+      }
+    }
+    Userbot.client = null;
+    Userbot.initPromise = null;
+  }
+
+  /**
    * Returns singleton instance of TelegramClient. To avoid a race condition
    * when multiple parts of the app request the client simultaneously, the
    * first call stores the initialization promise and subsequent calls await the

--- a/src/controllers/get-stories.ts
+++ b/src/controllers/get-stories.ts
@@ -84,6 +84,15 @@ export const getAllStoriesFx = createEffect(async (task: UserInfo) => {
 
   } catch (error: any) {
     console.error(`[GetStories] Error in getAllStoriesFx for task ${task.link}:`, error);
+    if (error?.message?.toLowerCase().includes('auth') && error?.message?.includes('key')) {
+      console.warn('[GetStories] Possible session error, reinitializing Userbot');
+      try {
+        await Userbot.reset();
+        await Userbot.getInstance();
+      } catch (reinitErr) {
+        console.error('[GetStories] Failed to reinitialize Userbot:', reinitErr);
+      }
+    }
     if (error instanceof FloodWaitError) {
       const seconds = error.seconds || 60;
       return `⚠️ Too many requests. Please wait about ${Math.ceil(seconds / 60)} minute(s).`;


### PR DESCRIPTION
## Summary
- add `Userbot.reset()` to allow reinitializing the Telegram client
- retry initialization when auth errors occur during profile fetch

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6844f4210a308326afac8223387d04fc