### PR TITLE
Improve error logging for Telegram message failures

### DIFF
--- a/src/controllers/get-stories.ts
+++ b/src/controllers/get-stories.ts
@@ -52,9 +52,15 @@ export const getAllStoriesFx = createEffect(async (task: UserInfo) => {
       let fetchedCountInLoop = 0;
       while (lastPinnedStoryId !== null) {
         await timeout(1000);
-        const olderPinnedResult = await client.invoke(
-          new Api.stories.GetPinnedStories({ peer: entity, offsetId: lastPinnedStoryId })
-        ).catch(() => null);
+        const olderPinnedResult = await client
+          .invoke(new Api.stories.GetPinnedStories({ peer: entity, offsetId: lastPinnedStoryId }))
+          .catch((err) => {
+            console.error(
+              `[getStories] Error fetching older pinned stories for ${task.link} (${task.chatId}):`,
+              err
+            );
+            return null;
+          });
 
         if (olderPinnedResult && olderPinnedResult.stories.length > 0) {
           const newPinnedStories = olderPinnedResult.stories.filter(

--- a/src/controllers/send-active-stories.ts
+++ b/src/controllers/send-active-stories.ts
@@ -61,7 +61,14 @@ export async function sendActiveStories({ stories, task }: SendStoriesArgs) {
 
   try {
     // --- User notification: downloading ---
-    await bot.telegram.sendMessage(task.chatId, '⏳ Downloading Active stories...').catch(() => null);
+    await bot.telegram
+      .sendMessage(task.chatId, '⏳ Downloading Active stories...')
+      .catch((err) => {
+        console.error(
+          `[sendActiveStories] Failed to send 'Downloading Active stories' message to ${task.chatId}:`,
+          err
+        );
+      });
 
     // --- Download stories to buffer ---
     await downloadStories(mapped, 'active');
@@ -73,10 +80,17 @@ export async function sendActiveStories({ stories, task }: SendStoriesArgs) {
 
     // --- Notify user about upload ---
     if (uploadableStories.length > 0) {
-      await bot.telegram.sendMessage(
-        task.chatId,
-        `📥 ${uploadableStories.length} Active stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
-      ).catch(() => null);
+      await bot.telegram
+        .sendMessage(
+          task.chatId,
+          `📥 ${uploadableStories.length} Active stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
+        )
+        .catch((err) => {
+          console.error(
+            `[sendActiveStories] Failed to send 'Uploading' message to ${task.chatId}:`,
+            err
+          );
+        });
 
       // --- Send in chunks (albums) ---
       const chunkedList = chunkMediafiles(uploadableStories);
@@ -135,7 +149,17 @@ export async function sendActiveStories({ stories, task }: SendStoriesArgs) {
     } as NotifyAdminParams);
     console.error('[sendActiveStories] Error sending ACTIVE stories:', error);
     try {
-      await bot.telegram.sendMessage(task.chatId, 'An error occurred while sending stories. The admin has been notified.').catch(() => null);
+      await bot.telegram
+        .sendMessage(
+          task.chatId,
+          'An error occurred while sending stories. The admin has been notified.'
+        )
+        .catch((err) => {
+          console.error(
+            `[sendActiveStories] Failed to notify ${task.chatId} about general error:`,
+            err
+          );
+        });
     } catch (_) {/* ignore */}
     throw error;
   }

--- a/src/controllers/send-paginated-stories.ts
+++ b/src/controllers/send-paginated-stories.ts
@@ -25,7 +25,14 @@ export async function sendPaginatedStories({
 
   try {
     // Notify user that download is starting
-    await bot.telegram.sendMessage(task.chatId, '⏳ Downloading...').catch(() => null);
+    await bot.telegram
+      .sendMessage(task.chatId, '⏳ Downloading...')
+      .catch((err) => {
+        console.error(
+          `[sendPaginatedStories] Failed to send 'Downloading' message to ${task.chatId}:`,
+          err
+        );
+      });
 
     // Actually download the stories (media files to buffer)
     await downloadStories(mapped, 'pinned'); // 'pinned' is a string literal, ok.
@@ -37,7 +44,14 @@ export async function sendPaginatedStories({
 
     if (uploadableStories.length > 0) {
       // Notify user that upload is starting
-      await bot.telegram.sendMessage(task.chatId, '⏳ Uploading to Telegram...').catch(() => null);
+      await bot.telegram
+        .sendMessage(task.chatId, '⏳ Uploading to Telegram...')
+        .catch((err) => {
+          console.error(
+            `[sendPaginatedStories] Failed to send 'Uploading' message to ${task.chatId}:`,
+            err
+          );
+        });
 
       // Send all media as a group (album)
       await bot.telegram.sendMediaGroup(
@@ -49,10 +63,17 @@ export async function sendPaginatedStories({
         }))
       );
     } else {
-      await bot.telegram.sendMessage(
-        task.chatId,
-        '❌ No paginated stories could be sent. They might be too large or none were found.'
-      ).catch(() => null);
+      await bot.telegram
+        .sendMessage(
+          task.chatId,
+          '❌ No paginated stories could be sent. They might be too large or none were found.'
+        )
+        .catch((err) => {
+          console.error(
+            `[sendPaginatedStories] Failed to notify ${task.chatId} about no stories:`,
+            err
+          );
+        });
     }
 
     // Notify admin for logging and monitoring
@@ -69,7 +90,17 @@ export async function sendPaginatedStories({
     } as NotifyAdminParams); // <--- Added type assertion for notifyAdmin params
     console.error('[sendPaginatedStories] Error occurred while sending paginated stories:', error);
     try {
-      await bot.telegram.sendMessage(task.chatId, 'An error occurred while sending these stories. The admin has been notified.').catch(() => null);
+      await bot.telegram
+        .sendMessage(
+          task.chatId,
+          'An error occurred while sending these stories. The admin has been notified.'
+        )
+        .catch((err) => {
+          console.error(
+            `[sendPaginatedStories] Failed to notify ${task.chatId} about general error:`,
+            err
+          );
+        });
     } catch (_) {/* ignore */}
     throw error; // Essential for Effector's .fail to trigger
   }

--- a/src/controllers/send-particular-story.ts
+++ b/src/controllers/send-particular-story.ts
@@ -25,7 +25,14 @@ export async function sendParticularStory({
 
   try {
     // Notify user that download is starting
-    await bot.telegram.sendMessage(task.chatId, '⏳ Downloading...').catch(() => null);
+    await bot.telegram
+      .sendMessage(task.chatId, '⏳ Downloading...')
+      .catch((err) => {
+        console.error(
+          `[sendParticularStory] Failed to send 'Downloading' message to ${task.chatId}:`,
+          err
+        );
+      });
 
     // Actually download the story (media file to buffer)
     await downloadStories(mapped, 'active'); // 'active' is a string literal, ok.
@@ -34,7 +41,14 @@ export async function sendParticularStory({
 
     if (singleStory && singleStory.buffer) { // <--- Added check for singleStory existence
       // Notify user that upload is starting
-      await bot.telegram.sendMessage(task.chatId, '⏳ Uploading to Telegram...').catch(() => null);
+      await bot.telegram
+        .sendMessage(task.chatId, '⏳ Uploading to Telegram...')
+        .catch((err) => {
+          console.error(
+            `[sendParticularStory] Failed to send 'Uploading' message to ${task.chatId}:`,
+            err
+          );
+        });
 
       // Send the media group (single file as an array)
       await bot.telegram.sendMediaGroup(task.chatId, [
@@ -48,7 +62,14 @@ export async function sendParticularStory({
       ]);
     } else {
       // Notify user if download failed
-      await bot.telegram.sendMessage(task.chatId, '❌ Could not retrieve the requested story.').catch(() => null);
+      await bot.telegram
+        .sendMessage(task.chatId, '❌ Could not retrieve the requested story.')
+        .catch((err) => {
+          console.error(
+            `[sendParticularStory] Failed to notify ${task.chatId} about retrieval error:`,
+            err
+          );
+        });
     }
 
     // Notify admin for monitoring
@@ -65,7 +86,17 @@ export async function sendParticularStory({
     } as NotifyAdminParams); // <--- Added type assertion for notifyAdmin params
     console.error('[sendParticularStory] Error occurred while sending story:', error);
     try {
-      await bot.telegram.sendMessage(task.chatId, 'An error occurred while sending this story. The admin has been notified.').catch(() => null);
+      await bot.telegram
+        .sendMessage(
+          task.chatId,
+          'An error occurred while sending this story. The admin has been notified.'
+        )
+        .catch((err) => {
+          console.error(
+            `[sendParticularStory] Failed to notify ${task.chatId} about general error:`,
+            err
+          );
+        });
     } catch (_) {/* ignore */}
     throw error; // Essential for Effector's .fail to trigger
   }

--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -82,10 +82,14 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
 
     console.log(`[SendPinnedStories] [${task.link}] Preparing to download ${mapped.length} pinned stories.`);
 
-    await bot.telegram.sendMessage(
-      task.chatId!,
-      '⏳ Downloading Pinned stories...'
-    ).catch(() => null);
+    await bot.telegram
+      .sendMessage(task.chatId!, '⏳ Downloading Pinned stories...')
+      .catch((err) => {
+        console.error(
+          `[SendPinnedStories] Failed to send 'Downloading Pinned stories' message to ${task.chatId}:`,
+          err
+        );
+      });
 
     // =========================================================================
     // CRITICAL STABILITY LOGIC: Download Timeout
@@ -106,10 +110,17 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
     console.log(`[SendPinnedStories] [${task.link}] Found ${uploadableStories.length} uploadable pinned stories after download.`);
 
     if (uploadableStories.length > 0) {
-      await bot.telegram.sendMessage(
-        task.chatId!,
-        `📥 ${uploadableStories.length} Pinned stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
-      ).catch(() => null);
+      await bot.telegram
+        .sendMessage(
+          task.chatId!,
+          `📥 ${uploadableStories.length} Pinned stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
+        )
+        .catch((err) => {
+          console.error(
+            `[SendPinnedStories] Failed to send 'Uploading' message to ${task.chatId}:`,
+            err
+          );
+        });
 
       const chunkedList = chunkMediafiles(uploadableStories);
       for (let i = 0; i < chunkedList.length; i++) {


### PR DESCRIPTION
## Summary
- handle message sending errors in controllers
- log context like function name and chat id on failures

## Testing
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6844f7d4a6108326bc7a6e49152c6538