### PR TITLE
Implement auto-deleting progress messages

### DIFF
--- a/src/controllers/get-stories.ts
+++ b/src/controllers/get-stories.ts
@@ -3,7 +3,7 @@
 import { Userbot } from 'config/userbot';
 import { createEffect } from 'effector';
 import { bot } from 'index';
-import { timeout } from 'lib';
+import { timeout, sendTemporaryMessage } from 'lib';
 import { UserInfo, NotifyAdminParams } from 'types';
 import { Api } from 'telegram';
 import { FloodWaitError } from 'telegram/errors';
@@ -16,7 +16,11 @@ import { notifyAdmin } from 'controllers/send-message';
 // =========================================================================
 export const getAllStoriesFx = createEffect(async (task: UserInfo) => {
   try {
-    await bot.telegram.sendMessage(task.chatId, '⏳ Fetching story lists...');
+    await sendTemporaryMessage(
+      bot,
+      task.chatId,
+      '⏳ Fetching story lists...'
+    );
 
     const client = await Userbot.getInstance();
     const entity = await client.getEntity(task.link);
@@ -116,7 +120,11 @@ export const getAllStoriesFx = createEffect(async (task: UserInfo) => {
 // =========================================================================
 export const getParticularStoryFx = createEffect(async (task: UserInfo) => {
   try {
-    await bot.telegram.sendMessage(task.chatId, '⏳ Fetching specific story...');
+    await sendTemporaryMessage(
+      bot,
+      task.chatId,
+      '⏳ Fetching specific story...'
+    );
 
     const client = await Userbot.getInstance();
     const linkPaths = task.link.split('/');

--- a/src/controllers/send-active-stories.ts
+++ b/src/controllers/send-active-stories.ts
@@ -2,7 +2,7 @@
 
 import { Userbot } from 'config/userbot';
 import { bot } from 'index'; // Corrected path to use tsconfig alias
-import { chunkMediafiles } from 'lib';
+import { chunkMediafiles, sendTemporaryMessage } from 'lib';
 import { Markup } from 'telegraf';
 import { Api } from 'telegram';
 
@@ -61,14 +61,16 @@ export async function sendActiveStories({ stories, task }: SendStoriesArgs) {
 
   try {
     // --- User notification: downloading ---
-    await bot.telegram
-      .sendMessage(task.chatId, '⏳ Downloading Active stories...')
-      .catch((err) => {
-        console.error(
-          `[sendActiveStories] Failed to send 'Downloading Active stories' message to ${task.chatId}:`,
-          err
-        );
-      });
+    await sendTemporaryMessage(
+      bot,
+      task.chatId,
+      '⏳ Downloading Active stories...'
+    ).catch((err) => {
+      console.error(
+        `[sendActiveStories] Failed to send 'Downloading Active stories' message to ${task.chatId}:`,
+        err
+      );
+    });
 
     // --- Download stories to buffer ---
     await downloadStories(mapped, 'active');
@@ -80,17 +82,16 @@ export async function sendActiveStories({ stories, task }: SendStoriesArgs) {
 
     // --- Notify user about upload ---
     if (uploadableStories.length > 0) {
-      await bot.telegram
-        .sendMessage(
-          task.chatId,
-          `📥 ${uploadableStories.length} Active stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
-        )
-        .catch((err) => {
-          console.error(
-            `[sendActiveStories] Failed to send 'Uploading' message to ${task.chatId}:`,
-            err
-          );
-        });
+      await sendTemporaryMessage(
+        bot,
+        task.chatId,
+        `📥 ${uploadableStories.length} Active stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
+      ).catch((err) => {
+        console.error(
+          `[sendActiveStories] Failed to send 'Uploading' message to ${task.chatId}:`,
+          err
+        );
+      });
 
       // --- Send in chunks (albums) ---
       const chunkedList = chunkMediafiles(uploadableStories);

--- a/src/controllers/send-paginated-stories.ts
+++ b/src/controllers/send-paginated-stories.ts
@@ -2,6 +2,7 @@
 
 import { bot } from 'index'; // Corrected path to use tsconfig alias
 import { Api } from 'telegram';
+import { sendTemporaryMessage } from 'lib';
 
 // CORRECTED: Import types from your central types.ts file
 import { SendPaginatedStoriesArgs, MappedStoryItem, NotifyAdminParams } from 'types'; // <--- Corrected import path & added MappedStoryItem, NotifyAdminParams
@@ -25,14 +26,14 @@ export async function sendPaginatedStories({
 
   try {
     // Notify user that download is starting
-    await bot.telegram
-      .sendMessage(task.chatId, '⏳ Downloading...')
-      .catch((err) => {
+    await sendTemporaryMessage(bot, task.chatId, '⏳ Downloading...').catch(
+      (err) => {
         console.error(
           `[sendPaginatedStories] Failed to send 'Downloading' message to ${task.chatId}:`,
           err
         );
-      });
+      }
+    );
 
     // Actually download the stories (media files to buffer)
     await downloadStories(mapped, 'pinned'); // 'pinned' is a string literal, ok.
@@ -44,14 +45,16 @@ export async function sendPaginatedStories({
 
     if (uploadableStories.length > 0) {
       // Notify user that upload is starting
-      await bot.telegram
-        .sendMessage(task.chatId, '⏳ Uploading to Telegram...')
-        .catch((err) => {
-          console.error(
-            `[sendPaginatedStories] Failed to send 'Uploading' message to ${task.chatId}:`,
-            err
-          );
-        });
+      await sendTemporaryMessage(
+        bot,
+        task.chatId,
+        '⏳ Uploading to Telegram...'
+      ).catch((err) => {
+        console.error(
+          `[sendPaginatedStories] Failed to send 'Uploading' message to ${task.chatId}:`,
+          err
+        );
+      });
 
       // Send all media as a group (album)
       await bot.telegram.sendMediaGroup(

--- a/src/controllers/send-particular-story.ts
+++ b/src/controllers/send-particular-story.ts
@@ -2,6 +2,7 @@
 
 import { bot } from 'index'; // Corrected path to use tsconfig alias
 import { Api } from 'telegram';
+import { sendTemporaryMessage } from 'lib';
 
 // CORRECTED: Import types from your central types.ts file
 import { SendParticularStoryArgs, UserInfo, MappedStoryItem, NotifyAdminParams } from 'types'; // <--- Corrected import path & added MappedStoryItem, NotifyAdminParams
@@ -25,14 +26,14 @@ export async function sendParticularStory({
 
   try {
     // Notify user that download is starting
-    await bot.telegram
-      .sendMessage(task.chatId, '⏳ Downloading...')
-      .catch((err) => {
+    await sendTemporaryMessage(bot, task.chatId, '⏳ Downloading...').catch(
+      (err) => {
         console.error(
           `[sendParticularStory] Failed to send 'Downloading' message to ${task.chatId}:`,
           err
         );
-      });
+      }
+    );
 
     // Actually download the story (media file to buffer)
     await downloadStories(mapped, 'active'); // 'active' is a string literal, ok.
@@ -41,14 +42,16 @@ export async function sendParticularStory({
 
     if (singleStory && singleStory.buffer) { // <--- Added check for singleStory existence
       // Notify user that upload is starting
-      await bot.telegram
-        .sendMessage(task.chatId, '⏳ Uploading to Telegram...')
-        .catch((err) => {
-          console.error(
-            `[sendParticularStory] Failed to send 'Uploading' message to ${task.chatId}:`,
-            err
-          );
-        });
+      await sendTemporaryMessage(
+        bot,
+        task.chatId,
+        '⏳ Uploading to Telegram...'
+      ).catch((err) => {
+        console.error(
+          `[sendParticularStory] Failed to send 'Uploading' message to ${task.chatId}:`,
+          err
+        );
+      });
 
       // Send the media group (single file as an array)
       await bot.telegram.sendMediaGroup(task.chatId, [

--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -3,7 +3,7 @@
 import { Userbot } from 'config/userbot';
 import { BOT_ADMIN_ID } from 'config/env-config';
 import { bot } from 'index';
-import { chunkMediafiles, timeout } from 'lib';
+import { chunkMediafiles, timeout, sendTemporaryMessage } from 'lib';
 import { Markup } from 'telegraf';
 import { Api } from 'telegram';
 
@@ -82,14 +82,16 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
 
     console.log(`[SendPinnedStories] [${task.link}] Preparing to download ${mapped.length} pinned stories.`);
 
-    await bot.telegram
-      .sendMessage(task.chatId!, '⏳ Downloading Pinned stories...')
-      .catch((err) => {
-        console.error(
-          `[SendPinnedStories] Failed to send 'Downloading Pinned stories' message to ${task.chatId}:`,
-          err
-        );
-      });
+    await sendTemporaryMessage(
+      bot,
+      task.chatId!,
+      '⏳ Downloading Pinned stories...'
+    ).catch((err) => {
+      console.error(
+        `[SendPinnedStories] Failed to send 'Downloading Pinned stories' message to ${task.chatId}:`,
+        err
+      );
+    });
 
     // =========================================================================
     // CRITICAL STABILITY LOGIC: Download Timeout
@@ -110,17 +112,16 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
     console.log(`[SendPinnedStories] [${task.link}] Found ${uploadableStories.length} uploadable pinned stories after download.`);
 
     if (uploadableStories.length > 0) {
-      await bot.telegram
-        .sendMessage(
-          task.chatId!,
-          `📥 ${uploadableStories.length} Pinned stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
-        )
-        .catch((err) => {
-          console.error(
-            `[SendPinnedStories] Failed to send 'Uploading' message to ${task.chatId}:`,
-            err
-          );
-        });
+      await sendTemporaryMessage(
+        bot,
+        task.chatId!,
+        `📥 ${uploadableStories.length} Pinned stories downloaded successfully!\n⏳ Uploading stories to Telegram...`
+      ).catch((err) => {
+        console.error(
+          `[SendPinnedStories] Failed to send 'Uploading' message to ${task.chatId}:`,
+          err
+        );
+      });
 
       const chunkedList = chunkMediafiles(uploadableStories);
       for (let i = 0; i < chunkedList.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import {
 } from './services/btc-payment';
 import { handleUpgrade } from 'controllers/upgrade';
 import { UserInfo } from 'types';
+import { sendTemporaryMessage } from 'lib';
 
 export const bot = new Telegraf<IContextBot>(BOT_TOKEN!);
 setBotInstance(bot);
@@ -83,7 +84,11 @@ bot.use(async (ctx, next) => {
     if (isUserPremium(String(id))) {
       const days = getPremiumDaysLeft(String(id));
       const daysText = days === Infinity ? 'unlimited' : days.toString();
-      await ctx.reply(`You have ${daysText} day${days === 1 ? '' : 's'} of Premium left.`).catch(() => {});
+      await sendTemporaryMessage(
+        bot,
+        ctx.chat!.id,
+        `You have ${daysText} day${days === 1 ? '' : 's'} of Premium left.`
+      ).catch(() => {});
     }
   } catch (e) {
     console.error('premium middleware error', e);

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -9,6 +9,22 @@ const MAX_STORIES_SIZE = 45;
 export const timeout = (ms: number): Promise<null> =>
   new Promise((ok) => setTimeout(ok, ms));
 
+// Send a Telegram message and automatically delete it after a delay
+export async function sendTemporaryMessage(
+  bot: import('telegraf').Telegraf<any>,
+  chatId: number | string,
+  text: string,
+  options?: Parameters<typeof bot.telegram.sendMessage>[2],
+  delayMs = 60_000,
+): Promise<void> {
+  const msg = await bot.telegram.sendMessage(chatId, text, options);
+  setTimeout(() => {
+    bot.telegram.deleteMessage(chatId, msg.message_id).catch(() => {
+      /* ignore deletion errors */
+    });
+  }, delayMs);
+}
+
 export function chunkMediafiles(files: StoriesModel): MappedStoryItem[][] { // Added return type and parameter type
   return files.reduce(
     (acc: MappedStoryItem[][], curr: MappedStoryItem) => { // CORRECTED: Explicitly typed 'acc' and 'curr'

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -12,6 +12,7 @@ import {
 } from 'db/effects'; 
 import { BOT_ADMIN_ID } from 'config/env-config';
 import { bot } from 'index';
+import { sendTemporaryMessage } from 'lib';
 import { UserInfo, DownloadQueueItem, SendStoriesFxParams } from 'types';
 import { getAllStoriesFx, getParticularStoryFx } from 'controllers/get-stories';
 import { sendStoriesFx } from 'controllers/send-stories';
@@ -38,13 +39,21 @@ export async function handleNewTask(user: UserInfo) {
         return;
       }
       if (await isDuplicatePendingFx({ telegram_id, target_username })) {
-        await bot.telegram.sendMessage(telegram_id, `⚠️ This download is already in the queue.`);
+        await sendTemporaryMessage(
+          bot,
+          telegram_id,
+          `⚠️ This download is already in the queue.`
+        );
         return;
       }
     }
 
     await enqueueDownloadFx({ telegram_id, target_username, task_details: user });
-    await bot.telegram.sendMessage(telegram_id, `✅ Your request for ${target_username} has been queued!`);
+    await sendTemporaryMessage(
+      bot,
+      telegram_id,
+      `✅ Your request for ${target_username} has been queued!`
+    );
     
     setImmediate(processQueue);
   } catch(e: any) {


### PR DESCRIPTION
## Summary
- add `sendTemporaryMessage` helper that deletes a message after 60 seconds
- use it for progress updates when fetching stories, downloading/uploading media, and queue notifications
- show premium days left via temporary message

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68450516ab78832686112746c29a5520