### PR TITLE
Add queue status updates and /queue command

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -10,9 +10,11 @@ import { DownloadQueueItem, UserInfo } from 'types';
 // ensuring no data is lost when a task is queued.
 // =========================================================================
 export const enqueueDownloadFx = createEffect(
-  async (params: { telegram_id: string; target_username: string; task_details: UserInfo }): Promise<void> => {
-    await db.enqueueDownload(params.telegram_id, params.target_username, params.task_details);
-  }
+  async (
+    params: { telegram_id: string; target_username: string; task_details: UserInfo },
+  ): Promise<number> => {
+    return db.enqueueDownload(params.telegram_id, params.target_username, params.task_details);
+  },
 );
 
 export const getNextQueueItemFx = createEffect<void, DownloadQueueItem | null>(() => db.getNextQueueItem());
@@ -40,6 +42,10 @@ export const isDuplicatePendingFx = createEffect(
     return db.isDuplicatePending(params.telegram_id, params.target_username);
   }
 );
+
+export const findPendingJobFx = createEffect((telegram_id: string) => db.findPendingJobId(telegram_id));
+
+export const getQueueStatsFx = createEffect((jobId: number) => db.getQueueStats(jobId));
 
 // Fetch recent history of downloads for admin reporting
 export const getRecentHistoryFx = createEffect((limit: number) => db.getRecentHistory(limit));

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import fs from 'fs';
 import path from 'path';
 import { db, resetStuckJobs, updateFromAddress } from './db';
 import { getRecentHistoryFx } from './db/effects';
-import { processQueue, handleNewTask } from './services/queue-manager';
+import { processQueue, handleNewTask, getQueueStatusForUser } from './services/queue-manager';
 import { saveUser } from './repositories/user-repository';
 import {
   isUserPremium,
@@ -168,6 +168,12 @@ bot.command('premium', async (ctx) => {
 
 bot.command('upgrade', async (ctx) => {
   await handleUpgrade(ctx);
+});
+
+bot.command('queue', async (ctx) => {
+  if (!isActivated(ctx.from.id)) return ctx.reply('Please type /start first.');
+  const msg = await getQueueStatusForUser(String(ctx.from.id));
+  await sendTemporaryMessage(bot, ctx.chat!.id, msg);
 });
 
 bot.command('monitor', async (ctx) => {
@@ -467,6 +473,7 @@ async function startApp() {
     { command: 'help', description: 'Show help message' },
     { command: 'premium', description: 'Info about premium features' },
     { command: 'upgrade', description: 'Upgrade to premium' },
+    { command: 'queue', description: 'Show your queue status' },
     { command: 'monitor', description: 'Monitor a profile for new stories' },
     { command: 'unmonitor', description: 'Stop monitoring a profile' },
   ]);


### PR DESCRIPTION
## Summary
- return queue row id when enqueuing
- provide helpers to calculate queue position and ETA
- show queue position after queueing
- add `/queue` command and register in bot commands
- expose queue utilities via service layer

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68450724bba483269b42bdef8fb3c67b