### PR TITLE
Fix duplicate job checks for paginated requests

### DIFF
--- a/__tests__/queue-manager.test.ts
+++ b/__tests__/queue-manager.test.ts
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+
+jest.mock('config/env-config', () => ({ BOT_ADMIN_ID: 0 }));
+
+// Avoid importing heavy dependencies when queue-manager is loaded
+jest.mock('controllers/get-stories', () => ({
+  getAllStoriesFx: jest.fn(),
+  getParticularStoryFx: jest.fn(),
+}));
+jest.mock('controllers/send-stories', () => ({ sendStoriesFx: jest.fn() }));
+
+const sendTemporaryMessage = jest.fn();
+jest.mock('../src/lib/index.ts', () => ({ sendTemporaryMessage }));
+
+const enqueueDownloadFx: any = jest.fn();
+const getQueueStatsFx: any = jest.fn();
+getQueueStatsFx.mockResolvedValue({ position: 1, eta: 0 });
+const wasRecentlyDownloadedFx: any = jest.fn();
+const isDuplicatePendingFx: any = jest.fn();
+
+jest.mock('db/effects', () => ({
+  enqueueDownloadFx,
+  getQueueStatsFx,
+  wasRecentlyDownloadedFx,
+  isDuplicatePendingFx,
+}));
+
+const bot = { telegram: { sendMessage: jest.fn() } } as any;
+jest.mock('index', () => ({ bot }));
+
+import { handleNewTask } from '../src/services/queue-manager';
+import { UserInfo } from '../src/types';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('queue-manager duplicate handling', () => {
+  test('rejects paginated request when duplicate pending', async () => {
+    isDuplicatePendingFx.mockResolvedValue(true);
+
+    const user: UserInfo = {
+      chatId: '1',
+      link: 'target',
+      linkType: 'username',
+      nextStoriesIds: [123],
+      locale: 'en',
+      initTime: Date.now(),
+    };
+
+    await handleNewTask(user);
+
+    expect(isDuplicatePendingFx).toHaveBeenCalledWith({ telegram_id: '1', target_username: 'target' });
+    expect(sendTemporaryMessage).toHaveBeenCalledWith(bot, '1', '⚠️ This download is already in the queue.');
+    expect(enqueueDownloadFx).not.toHaveBeenCalled();
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
     '^db/(.*)$': '<rootDir>/src/db/$1',
     '^services/(.*)$': '<rootDir>/src/services/$1',
     '^lib/(.*)$': '<rootDir>/src/lib/$1',
+    '^lib$': '<rootDir>/src/lib/index.ts',
     '^repositories/(.*)$': '<rootDir>/src/repositories/$1',
     '^types$': '<rootDir>/src/types.ts',
     '^index$': '<rootDir>/src/index.ts',

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -55,14 +55,15 @@ export async function handleNewTask(user: UserInfo) {
         await bot.telegram.sendMessage(telegram_id, `⏳ You can request stories for "${target_username}" once every ${cooldown} hours.`);
         return;
       }
-      if (await isDuplicatePendingFx({ telegram_id, target_username })) {
-        await sendTemporaryMessage(
-          bot,
-          telegram_id,
-          `⚠️ This download is already in the queue.`
-        );
-        return;
-      }
+    }
+
+    if (await isDuplicatePendingFx({ telegram_id, target_username })) {
+      await sendTemporaryMessage(
+        bot,
+        telegram_id,
+        `⚠️ This download is already in the queue.`
+      );
+      return;
     }
 
     const jobId = await enqueueDownloadFx({ telegram_id, target_username, task_details: user });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
       "db/*": ["db/*"],
       "services/*": ["services/*"],
       "lib/*": ["lib/*"],
+      "lib": ["lib/index.ts"],
       "repositories/*": ["repositories/*"],
       "types": ["types.ts"], // Maps 'types' alias directly to src/types.ts
       "index": ["index.ts"] // Maps 'index' alias directly to src/index.ts


### PR DESCRIPTION
## Summary
- always check for duplicate pending jobs regardless of pagination
- keep cooldown check gated for non‐paginated requests
- support `lib` alias in tsconfig and jest config
- test paginated duplicate handling

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684509bc40fc8326adf3f3af4278b32c