### PR TITLE
Implement bot blocking and download inactivity timeout

### DIFF
--- a/src/controllers/download-stories.ts
+++ b/src/controllers/download-stories.ts
@@ -29,8 +29,10 @@ import { MappedStoryItem, StoriesModel } from 'types'; // <--- This import is co
  */
 export async function downloadStories(
   stories: StoriesModel, // Already MappedStoryItem[]
-  storiesType: 'active' | 'pinned'
-): Promise<void> {
+  storiesType: 'active' | 'pinned',
+  onProgress?: (story: MappedStoryItem) => void,
+  signal?: AbortSignal,
+): Promise<number> {
   if (!stories || stories.length === 0) {
     console.log(`[DownloadStories] No ${storiesType} stories to download.`);
     return;
@@ -39,8 +41,9 @@ export async function downloadStories(
   const client = await Userbot.getInstance();
   console.log(`[DownloadStories] Starting download of ${stories.length} ${storiesType} stories. Concurrency: ${DOWNLOAD_CONCURRENCY_LIMIT}.`);
 
-  const downloadPromises = stories.map((storyItem: MappedStoryItem) => // Explicitly type storyItem
+  const downloadPromises = stories.map((storyItem: MappedStoryItem) =>
     limit(async () => {
+      if (signal?.aborted) return;
       const mediaExists = !!storyItem.media;
       const isNoforwards = !!storyItem.noforwards;
 
@@ -64,6 +67,7 @@ export async function downloadStories(
           storyItem.buffer = buffer;
           storyItem.bufferSize = parseFloat((buffer.byteLength / (1024 * 1024)).toFixed(2));
           console.log(`[DownloadStories] Downloaded story ID ${storyItem.id} (${storiesType}), Type: ${storyItem.mediaType}, Size: ${storyItem.bufferSize} MB.`);
+          onProgress?.(storyItem);
         } else {
           console.log(`[DownloadStories] Story ID ${storyItem.id} (${storiesType}): Empty or invalid buffer.`);
         }
@@ -89,6 +93,7 @@ export async function downloadStories(
   });
 
   console.log(`[DownloadStories] Finished all download attempts for ${stories.length} ${storiesType} stories. Success: ${successfulDownloads}, Failed: ${failedDownloads}.`);
+  return successfulDownloads;
 }
 
 // ===============================

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,3 +76,8 @@ export interface NotifyAdminParams {
   task?: UserInfo;
   errorInfo?: { cause: any; message?: string };
 }
+
+export interface BlockedUserRow {
+  telegram_id: string;
+  blocked_at: number;
+}


### PR DESCRIPTION
## Summary
- create database table for blocked users
- add helpers to block/unblock and list blocked users
- prevent bots and blocked accounts from using the bot
- add admin `/block`, `/unblock` and `/blocklist` commands
- time out paginated downloads if no activity occurs

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68450de0914c8326bd058a943b6467cd