### PR TITLE
Implement bot blocking and download inactivity timeout

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -76,3 +76,8 @@ export interface NotifyAdminParams {
   task?: UserInfo;
   errorInfo?: { cause: any; message?: string };
 }
+
+export interface BlockedUserRow {
+  telegram_id: string;
+  blocked_at: number;
+}


### PR DESCRIPTION
## Summary
- create database table for blocked users
- add helpers to block/unblock and list blocked users
- prevent bots and blocked accounts from using the bot
- add admin `/block`, `/unblock` and `/blocklist` commands
- time out paginated downloads if no activity occurs
- fix return type for `downloadStories`

## Testing
- `yarn install`
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68450de0914c8326bd058a943b6467cd