### PR TITLE
Add BTC payment tolerance

### DIFF
--- a/__tests__/btc-payment.test.ts
+++ b/__tests__/btc-payment.test.ts
@@ -10,6 +10,7 @@ jest.mock('../src/db', () => {
       user_id TEXT,
       invoice_amount REAL,
       user_address TEXT,
+      from_address TEXT,
       paid_amount REAL DEFAULT 0,
       expires_at INTEGER,
       paid_at INTEGER
@@ -17,10 +18,10 @@ jest.mock('../src/db', () => {
   `);
   return {
     db,
-    insertInvoice: (user_id: string, invoice_amount: number, user_address: string, expires_at: number) => {
+    insertInvoice: (user_id: string, invoice_amount: number, user_address: string, expires_at: number, from_address?: string | null) => {
       const result = db
-        .prepare(`INSERT INTO payments (user_id, invoice_amount, user_address, expires_at) VALUES (?, ?, ?, ?)`)
-        .run(user_id, invoice_amount, user_address, expires_at);
+        .prepare(`INSERT INTO payments (user_id, invoice_amount, user_address, from_address, expires_at) VALUES (?, ?, ?, ?, ?)`)
+        .run(user_id, invoice_amount, user_address, from_address ?? null, expires_at);
       const id = Number(result.lastInsertRowid);
       return db.prepare('SELECT * FROM payments WHERE id = ?').get(id);
     },
@@ -34,7 +35,7 @@ jest.mock('../src/db', () => {
 jest.mock('../src/config/env-config', () => ({ BTC_WALLET_ADDRESS: 'addr' }));
 
 // Import after mocks
-import { db } from '../src/db';
+import { db, markInvoicePaid, updatePaidAmount, insertInvoice } from '../src/db';
 import * as btc from '../src/services/btc-payment';
 
 describe('createInvoice rounding', () => {
@@ -61,6 +62,33 @@ describe('createInvoice rounding', () => {
     expect(invoice.invoice_amount).toBeCloseTo(expected, 8);
     const row = db.prepare('SELECT invoice_amount FROM payments WHERE id = ?').get(invoice.id) as any;
     expect(row.invoice_amount).toBeCloseTo(expected, 8);
+    global.fetch = originalFetch as any;
+  });
+});
+
+describe('checkPayment tolerance', () => {
+  beforeEach(() => {
+    db.prepare('DELETE FROM payments').run();
+    (markInvoicePaid as jest.Mock).mockClear();
+    (updatePaidAmount as jest.Mock).mockClear();
+  });
+
+  test('invoice marked paid when 90% received', async () => {
+    const invoice = insertInvoice('u1', 1, 'dest', 0, 'sender');
+
+    const tx = {
+      vout: [{ scriptpubkey_address: 'dest', value: 0.91 * 1e8 }],
+      vin: [{ prevout: { scriptpubkey_address: 'sender' } }],
+    };
+
+    const originalFetch = global.fetch;
+    global.fetch = (jest.fn() as any).mockResolvedValue({ json: async () => [tx] });
+
+    await btc.checkPayment(invoice as any);
+
+    expect(updatePaidAmount).toHaveBeenCalledWith(invoice.id, 0.91);
+    expect(markInvoicePaid).toHaveBeenCalledWith(invoice.id);
+
     global.fetch = originalFetch as any;
   });
 });


### PR DESCRIPTION
## Summary
- allow BTC payments slightly below invoice amount
- test `checkPayment` accepts 90% of invoice value

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684527a9bdac8326a7b63bb2e7791ea7