### PR TITLE
Add code block formatting for upgrade command

### DIFF
--- a/__tests__/upgrade-command.test.ts
+++ b/__tests__/upgrade-command.test.ts
@@ -31,6 +31,7 @@ describe('upgrade command', () => {
     expect(spy).toHaveBeenCalledWith('123', 5);
     expect(ctx.session.upgrade?.invoice).toBe(fakeInvoice);
     expect(replies.length).toBe(1);
+    expect(replies[0][0]).toContain('```');
     expect(replies[0][0]).toContain('addr');
     spy.mockRestore();
   });

--- a/src/controllers/upgrade.ts
+++ b/src/controllers/upgrade.ts
@@ -14,12 +14,18 @@ export async function handleUpgrade(ctx: IContextBot): Promise<void> {
       invoice,
       awaitingAddressUntil: Date.now() + 60 * 60 * 1000,
     };
-    await ctx.reply(
-      `Send *${invoice.invoice_amount.toFixed(8)} BTC* (~$5) to the following address:\n` +
-        `\`${invoice.user_address}\`\n` +
-        'Reply with the address you will pay from within one hour.',
-      { parse_mode: 'Markdown' },
-    );
+    const msg = [
+      'Send the following amount:',
+      '```',
+      `${invoice.invoice_amount.toFixed(8)} BTC`,
+      '```',
+      '\(~$5\) to the following address:',
+      '```',
+      invoice.user_address,
+      '```',
+      'Reply with the address you will pay from within one hour\.',
+    ].join('\n');
+    await ctx.reply(msg, { parse_mode: 'MarkdownV2' });
   } catch (e) {
     console.error('upgrade cmd error', e);
     await ctx.reply('Failed to create invoice. Please try again later.');


### PR DESCRIPTION
## Summary
- format BTC invoice reply with separate code blocks
- update tests to check for backticks

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684530c2afbc8326b989fd75d0b6ed0c