### PR TITLE
Add manual payment verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ Just send a message to the bot with the desired Telegram username, phone number,
 
 Free users cannot monitor profiles. Premium users can monitor up to **5** profiles for new stories, while admins have no limit. Each monitored account is checked every **6 hours** on its own schedule. Use `/monitor <@username|+19875551234>` to add a profile by username or phone number (digits only, no hyphens), and `/unmonitor <@username>` to remove one. After adding a monitor, the bot tells you how many slots you have left. Send `/monitor` or `/unmonitor` without arguments to see your current list.
 
+### Manual Payment Verification
+
+If your upgrade payment is not confirmed within an hour, you can verify it manually. Locate the invoice number in the upgrade reply (for example `Invoice #42`) and obtain the transaction hash (TXID) from your wallet. Then run:
+
+```
+/verify <txid> <invoice_id>
+```
+
+The bot will check the blockchain immediately and credit Premium time if the amount matches.
+
 ## Development
 
 Before running any build or lint commands, install dependencies:

--- a/__tests__/upgrade-command.test.ts
+++ b/__tests__/upgrade-command.test.ts
@@ -31,6 +31,7 @@ describe('upgrade command', () => {
     expect(spy).toHaveBeenCalledWith('123', 5);
     expect(ctx.session.upgrade?.invoice).toBe(fakeInvoice);
     expect(replies.length).toBe(1);
+    expect(replies[0][0]).toContain('Invoice #1');
     expect(replies[0][0]).toContain('```');
     expect(replies[0][0]).toContain('addr');
     spy.mockRestore();

--- a/src/controllers/upgrade.ts
+++ b/src/controllers/upgrade.ts
@@ -15,6 +15,7 @@ export async function handleUpgrade(ctx: IContextBot): Promise<void> {
       awaitingAddressUntil: Date.now() + 60 * 60 * 1000,
     };
     const msg = [
+      `Invoice #${invoice.id}`,
       'Send the following amount:',
       '```',
       `${invoice.invoice_amount.toFixed(8)} BTC`,


### PR DESCRIPTION
## Summary
- include invoice number in `/upgrade` reply
- send reminder to verify by txid after an hour
- support manual `/verify <txid> <invoice_id>` command
- implement `verifyPaymentByTxid` service
- document manual verification in README
- update tests for new behaviour

## Testing
- `yarn test` *(fails: findPackageLocation)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684535ed0ad08326b9fe03c0b62fba9a