### PR TITLE
Handle /verify for premium users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,6 +214,9 @@ bot.command('upgrade', async (ctx) => {
 bot.command('verify', async (ctx) => {
   const args = ctx.message.text.split(' ').slice(1);
   if (args.length < 2) {
+    if (isUserPremium(String(ctx.from.id))) {
+      return ctx.reply('✅ You already have Premium access.');
+    }
     return ctx.reply('Usage: /verify <txid> <invoice_id>');
   }
   const [txid, invoiceIdStr] = args;


### PR DESCRIPTION
## Summary
- respond with premium message when calling `/verify` with no args

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68454ce2f7e0832681a113611a5dcce0