### PR TITLE
Remove inline buttons on pagination

### DIFF
--- a/__tests__/callback-query.test.ts
+++ b/__tests__/callback-query.test.ts
@@ -1,0 +1,58 @@
+import { jest } from '@jest/globals';
+
+process.env.NODE_ENV = 'test';
+
+jest.mock('../src/config/env-config', () => ({
+  BOT_ADMIN_ID: 0,
+  BOT_TOKEN: 'token',
+  LOG_FILE: '/tmp/test.log',
+  isDevEnv: false,
+}));
+
+jest.mock('../src/services/monitor-service', () => ({
+  addProfileMonitor: jest.fn(),
+  removeProfileMonitor: jest.fn(),
+  userMonitorCount: jest.fn(),
+  listUserMonitors: jest.fn(),
+  startMonitorLoop: jest.fn(),
+  CHECK_INTERVAL_HOURS: 1,
+  MAX_MONITORS_PER_USER: 1,
+}));
+
+jest.mock('../src/services/btc-payment', () => ({
+  schedulePaymentCheck: jest.fn(),
+  resumePendingChecks: jest.fn(),
+  setBotInstance: jest.fn(),
+  verifyPaymentByTxid: jest.fn(),
+}));
+
+jest.mock('../src/services/premium-service', () => ({
+  isUserPremium: jest.fn().mockReturnValue(true),
+  addPremiumUser: jest.fn(),
+  removePremiumUser: jest.fn(),
+  extendPremium: jest.fn(),
+  getPremiumDaysLeft: jest.fn().mockReturnValue(0),
+}));
+
+jest.mock('../src/repositories/user-repository', () => ({ saveUser: jest.fn() }));
+
+const handleNewTask = jest.fn();
+jest.mock('../src/services/queue-manager', () => ({ handleNewTask }));
+
+import { handleCallbackQuery } from '../src/index';
+
+describe('callback query handler', () => {
+  test('removes inline keyboard after handling', async () => {
+    const ctx = {
+      callbackQuery: { data: 'user&[1]' },
+      from: { id: 1, language_code: 'en' },
+      editMessageReplyMarkup: jest.fn(),
+      answerCbQuery: jest.fn(),
+    } as any;
+
+    await handleCallbackQuery(ctx);
+
+    expect(handleNewTask).toHaveBeenCalled();
+    expect(ctx.editMessageReplyMarkup).toHaveBeenCalled();
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
     '^config/(.*)$': '<rootDir>/src/config/$1',
     '^controllers/(.*)$': '<rootDir>/src/controllers/$1',
     '^db/(.*)$': '<rootDir>/src/db/$1',
+    '^db$': '<rootDir>/src/db/index.ts',
     '^services/(.*)$': '<rootDir>/src/services/$1',
     '^lib/(.*)$': '<rootDir>/src/lib/$1',
     '^lib$': '<rootDir>/src/lib/index.ts',


### PR DESCRIPTION
## Summary
- remove pagination buttons once pressed
- avoid launching app when running tests
- map `db` alias in Jest
- test callback query handler clears reply markup

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68454e77fde48326b5698198a2a44803