### PR TITLE
Fix pinned stories message expiry

### DIFF
--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -162,8 +162,9 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
           },
           [] as InlineKeyboardButton[][]
         );
-        await bot.telegram.sendMessage(
-          task.chatId,
+        await sendTemporaryMessage(
+          bot,
+          task.chatId!,
           `Uploaded ${PER_PAGE}/${stories.length} pinned stories ✅`,
           Markup.inlineKeyboard(keyboard)
         );


### PR DESCRIPTION
## Summary
- make pinned stories upload confirmation temporary

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68454ffa18c08326b8602ca0e5a93b31