### PR TITLE
Fix paginated keyboard behavior

### DIFF
--- a/__tests__/callback-query.test.ts
+++ b/__tests__/callback-query.test.ts
@@ -55,4 +55,31 @@ describe('callback query handler', () => {
     expect(handleNewTask).toHaveBeenCalled();
     expect(ctx.editMessageReplyMarkup).toHaveBeenCalled();
   });
+
+  test('only removes pressed button from keyboard', async () => {
+    const ctx = {
+      callbackQuery: {
+        data: 'user&[2]',
+        message: {
+          reply_markup: {
+            inline_keyboard: [
+              [
+                { text: '1', callback_data: 'user&[1]' },
+                { text: '2', callback_data: 'user&[2]' },
+              ],
+            ],
+          },
+        },
+      },
+      from: { id: 1, language_code: 'en' },
+      editMessageReplyMarkup: jest.fn(),
+      answerCbQuery: jest.fn(),
+    } as any;
+
+    await handleCallbackQuery(ctx);
+
+    expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({
+      inline_keyboard: [[{ text: '1', callback_data: 'user&[1]' }]],
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,9 +518,22 @@ export async function handleCallbackQuery(ctx: IContextBot) {
     };
     handleNewTask(task);
     try {
-      await ctx.editMessageReplyMarkup(undefined);
+      const message = ctx.callbackQuery.message as any;
+      const markup = message?.reply_markup?.inline_keyboard;
+      if (markup) {
+        const newKeyboard = markup
+          .map((row: any[]) =>
+            row.filter((btn: any) => btn.callback_data !== data)
+          )
+          .filter((row: any[]) => row.length > 0);
+        await ctx.editMessageReplyMarkup(
+          newKeyboard.length ? { inline_keyboard: newKeyboard } : undefined
+        );
+      } else {
+        await ctx.editMessageReplyMarkup(undefined);
+      }
     } catch (e) {
-      console.error('Failed to clear inline keyboard:', e);
+      console.error('Failed to update inline keyboard:', e);
     }
     await ctx.answerCbQuery();
   }


### PR DESCRIPTION
## Summary
- keep other paginated keyboard buttons available after one is pressed
- add test to ensure pressed button is removed from keyboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845528061b4832689c251adbcd9fdd2