### PR TITLE
Fix duplicate check and keep keyboard alive

### DIFF
--- a/__tests__/queue-manager.test.ts
+++ b/__tests__/queue-manager.test.ts
@@ -50,7 +50,7 @@ describe('queue-manager duplicate handling', () => {
 
     await handleNewTask(user);
 
-    expect(isDuplicatePendingFx).toHaveBeenCalledWith({ telegram_id: '1', target_username: 'target' });
+    expect(isDuplicatePendingFx).toHaveBeenCalledWith({ telegram_id: '1', target_username: 'target', nextStoriesIds: [123] });
     expect(sendTemporaryMessage).toHaveBeenCalledWith(bot, '1', '⚠️ This download is already in the queue.');
     expect(enqueueDownloadFx).not.toHaveBeenCalled();
   });

--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -162,8 +162,7 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
           },
           [] as InlineKeyboardButton[][]
         );
-        await sendTemporaryMessage(
-          bot,
+        await bot.telegram.sendMessage(
           task.chatId!,
           `Uploaded ${PER_PAGE}/${stories.length} pinned stories ✅`,
           Markup.inlineKeyboard(keyboard)

--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -38,9 +38,15 @@ export const wasRecentlyDownloadedFx = createEffect(
 );
 
 export const isDuplicatePendingFx = createEffect(
-  async (params: { telegram_id: string; target_username: string }): Promise<boolean> => {
-    return db.isDuplicatePending(params.telegram_id, params.target_username);
-  }
+  async (
+    params: { telegram_id: string; target_username: string; nextStoriesIds?: number[] },
+  ): Promise<boolean> => {
+    return db.isDuplicatePending(
+      params.telegram_id,
+      params.target_username,
+      params.nextStoriesIds,
+    );
+  },
 );
 
 export const findPendingJobFx = createEffect((telegram_id: string) => db.findPendingJobId(telegram_id));

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -61,7 +61,7 @@ export async function handleNewTask(user: UserInfo) {
       }
     }
 
-    if (await isDuplicatePendingFx({ telegram_id, target_username })) {
+    if (await isDuplicatePendingFx({ telegram_id, target_username, nextStoriesIds })) {
       await sendTemporaryMessage(
         bot,
         telegram_id,


### PR DESCRIPTION
## Summary
- account for `nextStoriesIds` when checking for duplicate queue items
- pass `nextStoriesIds` through duplicate-check effect
- keep paginated keyboard message alive for pinned stories

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684554f05bac8326a47824e4d1237c3a