### PR TITLE
Fix premium command duplication

### DIFF
--- a/__tests__/premium-command.test.ts
+++ b/__tests__/premium-command.test.ts
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+
+process.env.NODE_ENV = 'test';
+
+jest.mock('../src/config/env-config', () => ({
+  BOT_ADMIN_ID: 0,
+  BOT_TOKEN: 'token',
+  LOG_FILE: '/tmp/test.log',
+}));
+
+const sendTemporaryMessage = jest.fn();
+jest.mock('../src/lib/helpers.ts', () => ({
+  ...(jest.requireActual('../src/lib/helpers.ts') as any),
+  sendTemporaryMessage,
+}));
+
+const bot = { telegram: { sendMessage: jest.fn() } } as any;
+jest.mock('../src/index.ts', () => ({ bot }));
+
+jest.mock('../src/services/premium-service', () => ({
+  isUserPremium: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../src/services/monitor-service', () => ({ MAX_MONITORS_PER_USER: 5 }));
+
+import { handlePremium } from '../src/controllers/premium';
+import { IContextBot } from '../src/config/context-interface';
+
+describe('handlePremium', () => {
+  test('sends temporary message for existing premium users', async () => {
+    const ctx = { from: { id: 1 }, chat: { id: 1 } } as unknown as IContextBot;
+
+    await handlePremium(ctx);
+
+    expect(sendTemporaryMessage).toHaveBeenCalledWith(bot, 1, '✅ You already have Premium access.');
+  });
+});

--- a/src/controllers/premium.ts
+++ b/src/controllers/premium.ts
@@ -1,0 +1,27 @@
+import { IContextBot } from 'config/context-interface';
+import { MAX_MONITORS_PER_USER } from 'services/monitor-service';
+import { isUserPremium } from 'services/premium-service';
+import { sendTemporaryMessage } from 'lib';
+import { bot } from 'index';
+
+/**
+ * Handle the `/premium` command.
+ * Shows upgrade info or notifies existing premium users.
+ */
+export async function handlePremium(ctx: IContextBot): Promise<void> {
+  const userId = String(ctx.from!.id);
+  if (isUserPremium(userId)) {
+    await sendTemporaryMessage(bot, ctx.chat!.id, '✅ You already have Premium access.');
+    return;
+  }
+  await ctx.reply(
+    '🌟 *Premium Access*\n\n' +
+      'Premium users get:\n' +
+      '✅ Unlimited story downloads\n' +
+      `✅ Monitor up to ${MAX_MONITORS_PER_USER} users' active stories\n` +
+      '✅ No cooldowns or waiting in queues\n\n' +
+      'Run `/upgrade` to unlock Premium features.\n' +
+      'You will receive a unique payment address. Invoices expire after one hour.',
+    { parse_mode: 'Markdown' },
+  );
+}


### PR DESCRIPTION
## Summary
- add Premium command controller
- avoid duplicate premium info from middleware
- auto-expire already-premium messages
- test premium command behavior

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68455cfd76c88326978b1c68153e2a69