### PR TITLE
Send active story caption as separate message

### DIFF
--- a/src/controllers/send-active-stories.ts
+++ b/src/controllers/send-active-stories.ts
@@ -101,9 +101,19 @@ export async function sendActiveStories({ stories, task }: SendStoriesArgs) {
           album.map((x: MappedStoryItem) => ({ // <--- 'x' is typed here
             media: { source: x.buffer! },
             type: x.mediaType,
-            caption: x.caption ?? `Active story from ${task.link}`,
+            caption: x.caption ?? undefined,
           }))
         );
+        await sendTemporaryMessage(
+          bot,
+          task.chatId,
+          `Active story from ${task.link}`,
+        ).catch((err) => {
+          console.error(
+            `[sendActiveStories] Failed to send temporary caption to ${task.chatId}:`,
+            err,
+          );
+        });
       }
     } else {
       await bot.telegram.sendMessage(


### PR DESCRIPTION
## Summary
- when sending active stories, send captions using `sendTemporaryMessage` so the text expires instead of being attached to media

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684560ae2cbc832690ea01c2081e1f6f