### PR TITLE
Add free trial upgrade

### DIFF
--- a/__tests__/premium-service.test.ts
+++ b/__tests__/premium-service.test.ts
@@ -1,4 +1,11 @@
-import { addPremiumUser, isUserPremium, removePremiumUser, getPremiumDaysLeft } from '../src/services/premium-service';
+import {
+  addPremiumUser,
+  isUserPremium,
+  removePremiumUser,
+  getPremiumDaysLeft,
+  grantFreeTrial,
+  hasUsedFreeTrial,
+} from '../src/services/premium-service';
 
 // Mock the ../db module used by premium-service to use an in-memory DB
 jest.mock('../src/db', () => {
@@ -9,6 +16,7 @@ jest.mock('../src/db', () => {
       telegram_id TEXT PRIMARY KEY NOT NULL,
       username TEXT,
       is_premium INTEGER DEFAULT 0,
+      free_trial_used INTEGER DEFAULT 0,
       premium_until INTEGER,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
@@ -53,5 +61,13 @@ describe('premium-service', () => {
     const daysLeft = getPremiumDaysLeft('4');
     expect(daysLeft).toBeGreaterThanOrEqual(1);
     expect(daysLeft).toBeLessThanOrEqual(2);
+  });
+
+  test('grantFreeTrial sets premium and marks trial used', () => {
+    grantFreeTrial('5');
+    const row = db.prepare('SELECT * FROM users WHERE telegram_id = ?').get('5') as any;
+    expect(row.is_premium).toBe(1);
+    expect(row.free_trial_used).toBe(1);
+    expect(hasUsedFreeTrial('5')).toBe(true);
   });
 });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -21,6 +21,7 @@ db.exec(`
     telegram_id TEXT PRIMARY KEY NOT NULL,
     username TEXT,
     is_premium INTEGER DEFAULT 0,
+    free_trial_used INTEGER DEFAULT 0,
     premium_until INTEGER,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
@@ -30,6 +31,9 @@ db.exec(`
 const userColumns = db.prepare("PRAGMA table_info(users)").all() as any[];
 if (!userColumns.some((c) => c.name === 'premium_until')) {
   db.exec('ALTER TABLE users ADD COLUMN premium_until INTEGER');
+}
+if (!userColumns.some((c) => c.name === 'free_trial_used')) {
+  db.exec("ALTER TABLE users ADD COLUMN free_trial_used INTEGER DEFAULT 0");
 }
 
 // Download Queue Table

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -9,6 +9,8 @@ export interface UserModel {
   telegram_id: string;
   username?: string;
   is_premium: 0 | 1; // SQLite stores booleans as 0 or 1
+  premium_until?: number | null;
+  free_trial_used?: 0 | 1;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- add `free_trial_used` column and migration
- implement free trial helpers in premium service
- notify new users about `/freetrial`
- add `/freetrial` command and command listing
- test new premium-service behaviour

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684562490e648326aec9905c830235b2