### PR TITLE
Fix persistent pagination buttons

### DIFF
--- a/src/controllers/send-active-stories.ts
+++ b/src/controllers/send-active-stories.ts
@@ -139,8 +139,7 @@ export async function sendActiveStories({ stories, task }: SendStoriesArgs) {
         acc[chunkIndex].push(curr);
         return acc;
       }, []);
-      await sendTemporaryMessage(
-        bot,
+      await bot.telegram.sendMessage(
         task.chatId,
         `Uploaded ${PER_PAGE}/${stories.length} active stories from ${task.link} ✅`,
         Markup.inlineKeyboard(keyboard)

--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -179,8 +179,7 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
           },
           [] as InlineKeyboardButton[][]
         );
-        await sendTemporaryMessage(
-          bot,
+        await bot.telegram.sendMessage(
           task.chatId!,
           `Uploaded ${PER_PAGE}/${stories.length} pinned stories ✅`,
           Markup.inlineKeyboard(keyboard)


### PR DESCRIPTION
## Summary
- keep pagination buttons until user clicks them

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68456b6bcd3083269d74323c08955e8d