### PR TITLE
Fix pinned stories captions

### DIFF
--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -179,10 +179,11 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
           },
           [] as InlineKeyboardButton[][]
         );
-        await bot.telegram.sendMessage(
+        await sendTemporaryMessage(
+          bot,
           task.chatId!,
           `Uploaded ${PER_PAGE}/${stories.length} pinned stories ✅`,
-          Markup.inlineKeyboard(keyboard)
+          Markup.inlineKeyboard(keyboard),
         );
       }
     } else {


### PR DESCRIPTION
## Summary
- show pinned story captions as temp messages in pagination view
- auto-expire summary text after uploading pinned stories

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68456f73314483268686b1f0d0c3fb4e