### PR TITLE
Fix pinned stories keyboard persistence

### DIFF
--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -179,8 +179,7 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
           },
           [] as InlineKeyboardButton[][]
         );
-        await sendTemporaryMessage(
-          bot,
+        await bot.telegram.sendMessage(
           task.chatId!,
           `Uploaded ${PER_PAGE}/${stories.length} pinned stories ✅`,
           Markup.inlineKeyboard(keyboard),


### PR DESCRIPTION
## Summary
- keep the inline keyboard message for pinned stories from being deleted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684571e4f58c832690cb365ee273769a