### PR TITLE
Separate pinned stories upload notice from keyboard

### DIFF
--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -179,10 +179,18 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
           },
           [] as InlineKeyboardButton[][]
         );
+        // Inform the user that some stories were uploaded, then provide a
+        // persistent keyboard for the remaining pages. The informational
+        // message is temporary so it does not interfere with the keyboard
+        // lifetime.
         await sendTemporaryMessage(
           bot,
           task.chatId!,
           `Uploaded ${PER_PAGE}/${stories.length} pinned stories ✅`,
+        );
+        await bot.telegram.sendMessage(
+          task.chatId!,
+          'Select another page of pinned stories:',
           Markup.inlineKeyboard(keyboard),
         );
       }


### PR DESCRIPTION
## Summary
- send a temporary completion message before showing keyboard for next pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684571e4f58c832690cb365ee273769a