### PR TITLE
Send pinned uploads info separately

### DIFF
--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -179,9 +179,14 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
           },
           [] as InlineKeyboardButton[][]
         );
-        await bot.telegram.sendMessage(
+        await sendTemporaryMessage(
+          bot,
           task.chatId!,
           `Uploaded ${PER_PAGE}/${stories.length} pinned stories ✅`,
+        );
+        await bot.telegram.sendMessage(
+          task.chatId!,
+          'Select the next batch of pinned stories:',
           Markup.inlineKeyboard(keyboard),
         );
       }


### PR DESCRIPTION
## Summary
- notify user that pinned stories were uploaded in a temporary message
- keep the "next batch" keyboard visible so it doesn't expire

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68457449776083268d84acb163361505