### PR TITLE
Auto-delete pagination keyboard

### DIFF
--- a/__tests__/callback-query.test.ts
+++ b/__tests__/callback-query.test.ts
@@ -82,4 +82,27 @@ describe('callback query handler', () => {
       inline_keyboard: [[{ text: '1', callback_data: 'user&[1]' }]],
     });
   });
+
+  test('deletes message when last button pressed', async () => {
+    const ctx = {
+      callbackQuery: {
+        data: 'user&[1]',
+        message: {
+          message_id: 42,
+          reply_markup: {
+            inline_keyboard: [[{ text: '1', callback_data: 'user&[1]' }]],
+          },
+        },
+      },
+      from: { id: 1, language_code: 'en' },
+      editMessageReplyMarkup: jest.fn(),
+      deleteMessage: jest.fn(),
+      answerCbQuery: jest.fn(),
+    } as any;
+
+    await handleCallbackQuery(ctx);
+
+    expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith(undefined);
+    expect(ctx.deleteMessage).toHaveBeenCalled();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -532,6 +532,13 @@ export async function handleCallbackQuery(ctx: IContextBot) {
         await ctx.editMessageReplyMarkup(
           newKeyboard.length ? { inline_keyboard: newKeyboard } : undefined
         );
+        if (newKeyboard.length === 0) {
+          try {
+            await ctx.deleteMessage();
+          } catch {
+            /* ignore */
+          }
+        }
       } else {
         await ctx.editMessageReplyMarkup(undefined);
       }


### PR DESCRIPTION
## Summary
- clean up pinned stories keyboard when last button pressed
- cover this with a new callback-query unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684577fa835883268349e959d5d58d69