### PR TITLE
Add profile media support

### DIFF
--- a/src/controllers/send-profile-media.ts
+++ b/src/controllers/send-profile-media.ts
@@ -1,0 +1,60 @@
+import { Userbot } from 'config/userbot';
+import { bot } from 'index';
+import { sendTemporaryMessage } from 'lib';
+import { Api } from 'telegram';
+import { notifyAdmin } from 'controllers/send-message';
+// No need for the private _downloadPhoto helper; use downloadMedia instead
+
+/**
+ * Download and send profile photos and videos for a given username or phone number.
+ * Sends up to LIMIT items as a media group.
+ */
+export async function sendProfileMedia(
+  chatId: number | string,
+  input: string,
+  limit = 3,
+) {
+  try {
+    await sendTemporaryMessage(bot, chatId, `⏳ Fetching profile media for ${input}...`);
+
+    const client = await Userbot.getInstance();
+    const entity = await client.getEntity(input);
+
+    const result = (await client.invoke(
+      new Api.photos.GetUserPhotos({ userId: entity, offset: 0, limit })
+    )) as Api.photos.Photos;
+
+    const photos = 'photos' in result ? result.photos : [];
+    if (!photos.length) {
+      await bot.telegram.sendMessage(chatId, 'No profile media found.');
+      return;
+    }
+
+    const sendAlbum = [] as { media: { source: Buffer }; type: 'photo' | 'video' }[];
+    for (const photo of photos.slice(0, limit)) {
+      if (!(photo instanceof Api.Photo)) continue;
+      try {
+        const buffer = (await client.downloadMedia(photo as any)) as Buffer;
+        if (Buffer.isBuffer(buffer)) {
+          const isVideo = 'videoSizes' in photo && Array.isArray((photo as any).videoSizes) && (photo as any).videoSizes.length > 0;
+          sendAlbum.push({ media: { source: buffer }, type: isVideo ? 'video' : 'photo' });
+        }
+      } catch (e) {
+        console.error('[sendProfileMedia] Error downloading media:', e);
+      }
+    }
+
+    if (sendAlbum.length) {
+      await bot.telegram.sendMediaGroup(chatId, sendAlbum);
+      notifyAdmin({ status: 'info', baseInfo: `📸 Sent ${sendAlbum.length} profile media item(s) of ${input}` });
+    } else {
+      await bot.telegram.sendMessage(chatId, 'Failed to download profile media.');
+    }
+  } catch (e) {
+    console.error('[sendProfileMedia] Error:', e);
+    notifyAdmin({ status: 'error', errorInfo: { cause: e } });
+    await bot.telegram.sendMessage(chatId, 'Error retrieving profile media.');
+  }
+}
+
+export default sendProfileMedia;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import {
 } from './services/btc-payment';
 import { handleUpgrade } from 'controllers/upgrade';
 import { handlePremium } from 'controllers/premium';
+import { sendProfileMedia } from 'controllers/send-profile-media';
 import { UserInfo } from 'types';
 import { sendTemporaryMessage } from 'lib';
 
@@ -72,6 +73,7 @@ const BASE_COMMANDS = [
   { command: 'freetrial', description: 'Free 7-day premium trial' },
   { command: 'verify', description: 'Manually verify a payment' },
   { command: 'queue', description: 'Show your queue status' },
+  { command: 'profile', description: 'Get profile media for a user' },
 ];
 
 const PREMIUM_COMMANDS = [
@@ -214,6 +216,7 @@ bot.command('help', async (ctx) => {
     '`/premium` - Info about premium features\n' +
     '`/freetrial` - Get 7 days of Premium access\n' +
     '`/queue` - View your place in the download queue\n' +
+    '`/profile` - Get profile media\n' +
     '`/verify <txid> <invoice>` - Manually verify a payment if it is not detected\n';
 
   const isAdmin = ctx.from.id === BOT_ADMIN_ID;
@@ -293,6 +296,16 @@ bot.command('queue', async (ctx) => {
   if (!isActivated(ctx.from.id)) return ctx.reply('Please type /start first.');
   const msg = await getQueueStatusForUser(String(ctx.from.id));
   await sendTemporaryMessage(bot, ctx.chat!.id, msg);
+});
+
+bot.command('profile', async (ctx) => {
+  if (!isActivated(ctx.from.id)) return ctx.reply('Please type /start first.');
+  const args = ctx.message.text.split(' ').slice(1);
+  if (args.length === 0) {
+    return ctx.reply('Usage: /profile <@username|+phone>');
+  }
+  const input = args[0];
+  await sendProfileMedia(ctx.chat!.id, input);
 });
 
 bot.command('monitor', async (ctx) => {


### PR DESCRIPTION
## Summary
- support profile videos in send-profile-media
- update command descriptions and help text
- clarify profile command usage in help message

## Testing
- `yarn test`
- `yarn build`
- `yarn lint` *(fails: couldn't find an ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6845f3ff9cdc8326bd3b790667ce3dff