### PR TITLE
Fix duplicate profile media notifications

### DIFF
--- a/__tests__/send-profile-media.test.ts
+++ b/__tests__/send-profile-media.test.ts
@@ -53,6 +53,7 @@ describe('sendProfileMedia', () => {
     const total = (bot.telegram.sendMediaGroup as jest.Mock).mock.calls
       .reduce((sum: number, c: any[]) => sum + c[1].length, 0);
     expect(total).toBe(11);
+    expect(sendTemporaryMessage).toHaveBeenCalledTimes(1);
     expect(sendTemporaryMessage).toHaveBeenCalledWith(
       bot,
       1,

--- a/src/controllers/send-profile-media.ts
+++ b/src/controllers/send-profile-media.ts
@@ -15,7 +15,6 @@ export async function sendProfileMedia(
   limit?: number,
 ) {
   try {
-    await sendTemporaryMessage(bot, chatId, `⏳ Fetching profile media for ${input}...`);
 
     const client = await Userbot.getInstance();
     const entity = await client.getEntity(input);


### PR DESCRIPTION
## Summary
- avoid sending progress message while fetching profile media
- assert only one temporary message is sent in tests

## Testing
- `yarn test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684602bd16608326b098aaa0eca4c082