### PR TITLE
Fix duplicate profile media message for admin

### DIFF
--- a/src/controllers/send-profile-media.ts
+++ b/src/controllers/send-profile-media.ts
@@ -64,7 +64,11 @@ export async function sendProfileMedia(
         chatId,
         `📸 Sent ${sendAlbum.length} profile media item(s) of ${input}`,
       );
-      notifyAdmin({ status: 'info', baseInfo: `📸 Sent ${sendAlbum.length} profile media item(s) of ${input}` });
+      notifyAdmin({
+        status: 'info',
+        baseInfo: `📸 Sent ${sendAlbum.length} profile media item(s) of ${input}`,
+        task: { chatId: String(chatId) } as any,
+      });
     } else {
       await bot.telegram.sendMessage(chatId, 'Failed to download profile media.');
     }


### PR DESCRIPTION
## Summary
- avoid duplicate admin notification in `sendProfileMedia`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460790d92483268c15c26211ef1c9b