### PR TITLE
Improve admin audit messages for profile downloads

### DIFF
--- a/__tests__/send-profile-media.test.ts
+++ b/__tests__/send-profile-media.test.ts
@@ -47,7 +47,7 @@ describe('sendProfileMedia', () => {
     };
     (mockGetInstance as any).mockResolvedValue(fakeClient);
 
-    await sendProfileMedia(1, '@user');
+    await sendProfileMedia(1, '@user', { id: 42, username: 'tester' } as any);
 
     expect(bot.telegram.sendMediaGroup).toHaveBeenCalledTimes(2);
     const total = (bot.telegram.sendMediaGroup as jest.Mock).mock.calls
@@ -58,6 +58,13 @@ describe('sendProfileMedia', () => {
       bot,
       1,
       '📸 Sent 11 profile media item(s) of @user',
+    );
+    expect(notifyAdmin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'info',
+        baseInfo: '📸 Sent 11 profile media item(s) of @user',
+        task: { chatId: '1', user: { id: 42, username: 'tester' } },
+      }),
     );
   });
 });

--- a/src/controllers/send-profile-media.ts
+++ b/src/controllers/send-profile-media.ts
@@ -3,15 +3,22 @@ import { bot } from 'index';
 import { sendTemporaryMessage, chunkArray } from 'lib';
 import { Api } from 'telegram';
 import { notifyAdmin } from 'controllers/send-message';
+import { User } from 'telegraf/typings/core/types/typegram';
 // No need for the private _downloadPhoto helper; use downloadMedia instead
 
 /**
  * Download and send profile photos and videos for a given username or phone number.
  * Sends up to LIMIT items as a media group.
+ *
+ * @param chatId - ID of the chat to send media to
+ * @param input - Username or phone number to look up
+ * @param user - Telegram user requesting the media (for admin audit)
+ * @param limit - Optional limit on number of items to fetch
  */
 export async function sendProfileMedia(
   chatId: number | string,
   input: string,
+  user?: User,
   limit?: number,
 ) {
   try {
@@ -67,7 +74,7 @@ export async function sendProfileMedia(
       notifyAdmin({
         status: 'info',
         baseInfo: `📸 Sent ${sendAlbum.length} profile media item(s) of ${input}`,
-        task: { chatId: String(chatId) } as any,
+        task: { chatId: String(chatId), user } as any,
       });
     } else {
       await bot.telegram.sendMessage(chatId, 'Failed to download profile media.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,7 +324,7 @@ bot.command('profile', async (ctx) => {
   }
 
   await recordProfileRequestFx({ telegram_id: userId, target_username: input });
-  await sendProfileMedia(ctx.chat!.id, input);
+  await sendProfileMedia(ctx.chat!.id, input, ctx.from);
 });
 
 bot.command('monitor', async (ctx) => {


### PR DESCRIPTION
## Summary
- log which user requested profile media in notifications
- pass user info from `/profile` command to the media sender
- cover new parameter in tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68460f8bbb6083268dc72c0e10bd761a