### PR TITLE
Add cooldown timer to warnings

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -37,6 +37,11 @@ export const wasRecentlyDownloadedFx = createEffect(
   }
 );
 
+export const getDownloadCooldownRemainingFx = createEffect(
+  (params: { telegram_id: string; target_username: string; hours: number }) =>
+    db.getDownloadCooldownRemaining(params.telegram_id, params.target_username, params.hours),
+);
+
 export const isDuplicatePendingFx = createEffect(
   async (
     params: { telegram_id: string; target_username: string; nextStoriesIds?: number[] },
@@ -64,4 +69,13 @@ export const recordProfileRequestFx = createEffect(
 export const wasProfileRequestedRecentlyFx = createEffect(
   (params: { telegram_id: string; target_username: string; hours: number }) =>
     db.wasProfileRequestedRecently(params.telegram_id, params.target_username, params.hours),
+);
+
+export const getProfileRequestCooldownRemainingFx = createEffect(
+  (params: { telegram_id: string; target_username: string; hours: number }) =>
+    db.getProfileRequestCooldownRemaining(
+      params.telegram_id,
+      params.target_username,
+      params.hours,
+    ),
 );

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -8,6 +8,7 @@ import {
   markErrorFx,
   cleanupQueueFx,
   wasRecentlyDownloadedFx,
+  getDownloadCooldownRemainingFx,
   isDuplicatePendingFx,
   getQueueStatsFx,
   findPendingJobFx,
@@ -56,7 +57,14 @@ export async function handleNewTask(user: UserInfo) {
 
     if (!isPaginatedRequest) {
       if (await wasRecentlyDownloadedFx({ telegram_id, target_username, hours: cooldown })) {
-        await bot.telegram.sendMessage(telegram_id, `⏳ You can request stories for "${target_username}" once every ${cooldown} hours.`);
+        const remaining = await getDownloadCooldownRemainingFx({ telegram_id, target_username, hours: cooldown });
+        const h = Math.floor(remaining / 3600);
+        const m = Math.floor((remaining % 3600) / 60);
+        await sendTemporaryMessage(
+          bot,
+          telegram_id,
+          `⏳ You can request stories for "${target_username}" once every ${cooldown} hours.\nTry again in ${h}h ${m}m.`,
+        );
         return;
       }
     }


### PR DESCRIPTION
## Summary
- add functions to calculate remaining cooldown time in the DB layer
- expose new effects for remaining cooldown checks
- show remaining cooldown when warning about download or profile limits
- make these warning messages temporary

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684611da33a08326a3a31d8b2814edcf