### PR TITLE
Implement premium pinned status message

### DIFF
--- a/__tests__/send-stories.test.ts
+++ b/__tests__/send-stories.test.ts
@@ -1,5 +1,13 @@
 import { jest } from '@jest/globals';
 
+process.env.NODE_ENV = 'test';
+
+jest.mock('../src/config/env-config', () => ({
+  BOT_ADMIN_ID: 0,
+  BOT_TOKEN: 'token',
+  LOG_FILE: '/tmp/test.log',
+}));
+
 const sendParticularStory = jest.fn();
 jest.mock('../src/controllers/send-particular-story', () => ({ sendParticularStory }));
 const sendPaginatedStories = jest.fn();

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -35,6 +35,9 @@ if (!userColumns.some((c) => c.name === 'premium_until')) {
 if (!userColumns.some((c) => c.name === 'free_trial_used')) {
   db.exec("ALTER TABLE users ADD COLUMN free_trial_used INTEGER DEFAULT 0");
 }
+if (!userColumns.some((c) => c.name === 'pinned_message_id')) {
+  db.exec('ALTER TABLE users ADD COLUMN pinned_message_id INTEGER');
+}
 
 // Download Queue Table
 // CHANGE 1: Added the `task_details` column to store the full UserInfo object as JSON text.

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ import { handleUpgrade } from 'controllers/upgrade';
 import { handlePremium } from 'controllers/premium';
 import { sendProfileMedia } from 'controllers/send-profile-media';
 import { UserInfo } from 'types';
-import { sendTemporaryMessage } from 'lib';
+import { sendTemporaryMessage, updatePremiumPinnedMessage } from 'lib';
 import {
   recordProfileRequestFx,
   wasProfileRequestedRecentlyFx,
@@ -168,12 +168,7 @@ bot.use(async (ctx, next) => {
     if (text.startsWith('/premium')) return;
     if (isUserPremium(String(id))) {
       const days = getPremiumDaysLeft(String(id));
-      const daysText = days === Infinity ? 'unlimited' : days.toString();
-      await sendTemporaryMessage(
-        bot,
-        ctx.chat!.id,
-        `You have ${daysText} day${days === 1 ? '' : 's'} of Premium left.`
-      ).catch(() => {});
+      await updatePremiumPinnedMessage(bot, ctx.chat!.id, String(id), days);
     }
   } catch (e) {
     console.error('premium middleware error', e);

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -11,6 +11,7 @@ export interface UserModel {
   is_premium: 0 | 1; // SQLite stores booleans as 0 or 1
   premium_until?: number | null;
   free_trial_used?: 0 | 1;
+  pinned_message_id?: number | null;
   created_at: string;
 }
 
@@ -72,5 +73,31 @@ export const findUserById = (telegram_id: string): UserModel | undefined => {
   } catch (error) {
     console.error(`[DB] Error finding user ${telegram_id}:`, error);
     return undefined;
+  }
+};
+
+export const getPinnedMessageId = (telegramId: string): number | undefined => {
+  try {
+    const row = db
+      .prepare('SELECT pinned_message_id FROM users WHERE telegram_id = ?')
+      .get(telegramId) as { pinned_message_id?: number } | undefined;
+    return row?.pinned_message_id;
+  } catch (error) {
+    console.error(`[DB] Error getting pinned message id for ${telegramId}:`, error);
+    return undefined;
+  }
+};
+
+export const setPinnedMessageId = (
+  telegramId: string,
+  messageId: number | null,
+): void => {
+  try {
+    db.prepare('UPDATE users SET pinned_message_id = ? WHERE telegram_id = ?').run(
+      messageId,
+      telegramId,
+    );
+  } catch (error) {
+    console.error(`[DB] Error setting pinned message id for ${telegramId}:`, error);
   }
 };


### PR DESCRIPTION
## Summary
- pin a premium status message instead of ephemeral alerts
- support storing pinned message id per user
- update tests to mock env config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846138591588326a4c6aeb81c730b12