### PR TITLE
Show bot status in user lists

### DIFF
--- a/__tests__/premium-service.test.ts
+++ b/__tests__/premium-service.test.ts
@@ -15,6 +15,7 @@ jest.mock('../src/db', () => {
     CREATE TABLE users (
       telegram_id TEXT PRIMARY KEY NOT NULL,
       username TEXT,
+      is_bot INTEGER DEFAULT 0,
       is_premium INTEGER DEFAULT 0,
       free_trial_used INTEGER DEFAULT 0,
       premium_until INTEGER,

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -8,6 +8,7 @@ import { User } from 'telegraf/typings/core/types/typegram';
 export interface UserModel {
   telegram_id: string;
   username?: string;
+  is_bot?: number;
   is_premium: 0 | 1; // SQLite stores booleans as 0 or 1
   premium_until?: number | null;
   free_trial_used?: 0 | 1;
@@ -22,16 +23,17 @@ export interface UserModel {
  * Only called when a user sends /start for the first time.
  */
 export const saveUser = (user: User) => {
-  try {
-    const telegramId = user.id.toString();
-    const username = user.username || null;
+  try {
+    const telegramId = user.id.toString();
+    const username = user.username || null;
+    const isBot = user.is_bot ? 1 : 0;
 
     const exists = db.prepare('SELECT 1 FROM users WHERE telegram_id = ?').get(telegramId);
 
     if (!exists) {
-      db.prepare(
-        'INSERT INTO users (telegram_id, username) VALUES (?, ?)'
-      ).run(telegramId, username);
+      db.prepare(
+        'INSERT INTO users (telegram_id, username, is_bot) VALUES (?, ?, ?)'
+      ).run(telegramId, username, isBot);
 
       notifyAdmin({
         status: 'info',

--- a/src/services/premium-service.ts
+++ b/src/services/premium-service.ts
@@ -3,6 +3,7 @@ import { db } from '../db';
 export interface UserRow {
   telegram_id?: string;
   username?: string;
+  is_bot?: number;
   is_premium?: number;
   premium_until?: number | null;
   free_trial_used?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,4 +81,5 @@ export interface NotifyAdminParams {
 export interface BlockedUserRow {
   telegram_id: string;
   blocked_at: number;
+  is_bot: number;
 }


### PR DESCRIPTION
## Summary
- track whether users are bots in the database
- store bot info for blocked users
- surface bot information in `/users`, `/blocklist`, `/listpremium` and `/history`
- adjust tests for new DB schema

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68461d5046048326bc084c03c04a4833