### PR TITLE
Add BTC_ZPUB support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ BOT_ADMIN_ID=
 NODE_ENV=
 # Either a fixed wallet address or an extended public key for deriving unique addresses
 BTC_WALLET_ADDRESS=
-# If both are set, BTC_XPUB overrides BTC_WALLET_ADDRESS and derived addresses will be used
+# If one of BTC_XPUB or BTC_ZPUB is set, it overrides BTC_WALLET_ADDRESS and derived addresses will be used
 BTC_XPUB=
+BTC_ZPUB=
 
 # Optional: where to store error logs
 LOG_FILE=./data/error.log

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ bot.telegram.sendMediaGroup(
    - <code>USERBOT_PHONE_NUMBER</code> – the phone number of the account that will act as the userbot.
    - Optional: <code>USERBOT_PASSWORD</code> if that account has two‑factor authentication enabled.
    - Leave <code>USERBOT_PHONE_CODE</code> empty for the first run.
-  - Fill in <code>BOT_ADMIN_ID</code>, and either <code>BTC_WALLET_ADDRESS</code> or <code>BTC_XPUB</code>.
-    If both are provided, <code>BTC_XPUB</code> takes precedence and new invoices
+  - Fill in <code>BOT_ADMIN_ID</code>, and either <code>BTC_WALLET_ADDRESS</code>, <code>BTC_XPUB</code>, or <code>BTC_ZPUB</code>.
+    If an extended public key is provided via <code>BTC_XPUB</code> or <code>BTC_ZPUB</code>, it takes precedence and new invoices
     will derive unique addresses from it.
   - Optional: <code>LOG_FILE</code> to change where runtime errors are logged (defaults to <code>./data/error.log</code>).
   - Optional: <code>DEBUG_LOG_FILE</code> to also store verbose debug logs on disk. Leave empty to disable file logging.

--- a/__tests__/btc-payment.test.ts
+++ b/__tests__/btc-payment.test.ts
@@ -52,7 +52,7 @@ jest.mock('../src/db', () => {
 });
 
 // Mock env-config to supply wallet address
-jest.mock('../src/config/env-config', () => ({ BTC_WALLET_ADDRESS: 'addr', BTC_XPUB: '' }));
+jest.mock('../src/config/env-config', () => ({ BTC_WALLET_ADDRESS: 'addr', BTC_XPUB: '', BTC_ZPUB: '' }));
 
 // Import after mocks
 import { db, markInvoicePaid, updatePaidAmount, updateFromAddress, recordTxid, isTxidUsed, insertInvoice } from '../src/db';

--- a/__tests__/upgrade-command.test.ts
+++ b/__tests__/upgrade-command.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 // Mock env-config to avoid requiring actual environment variables
-jest.mock('../src/config/env-config', () => ({ BTC_WALLET_ADDRESS: 'addr', BTC_XPUB: '' }));
+jest.mock('../src/config/env-config', () => ({ BTC_WALLET_ADDRESS: 'addr', BTC_XPUB: '', BTC_ZPUB: '' }));
 
 import { handleUpgrade } from '../src/controllers/upgrade';
 import { IContextBot } from '../src/config/context-interface';

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -35,10 +35,11 @@ export const USERBOT_PHONE_CODE = process.env.USERBOT_PHONE_CODE || parsed?.USER
 
 // payments
 export const BTC_XPUB = process.env.BTC_XPUB || parsed?.BTC_XPUB || '';
+export const BTC_ZPUB = process.env.BTC_ZPUB || parsed?.BTC_ZPUB || '';
 export const BTC_WALLET_ADDRESS =
   process.env.BTC_WALLET_ADDRESS || parsed?.BTC_WALLET_ADDRESS || '';
-if (!BTC_WALLET_ADDRESS && !BTC_XPUB) {
-  throw new Error('Either BTC_WALLET_ADDRESS or BTC_XPUB is required');
+if (!BTC_WALLET_ADDRESS && !BTC_XPUB && !BTC_ZPUB) {
+  throw new Error('Either BTC_WALLET_ADDRESS, BTC_XPUB or BTC_ZPUB is required');
 }
 
 // error log file path

--- a/src/services/btc-payment.ts
+++ b/src/services/btc-payment.ts
@@ -15,7 +15,7 @@ import {
   reserveAddressIndex,
 } from '../db';
 import { IContextBot } from 'config/context-interface';
-import { BTC_WALLET_ADDRESS, BTC_XPUB } from 'config/env-config';
+import { BTC_WALLET_ADDRESS, BTC_XPUB, BTC_ZPUB } from 'config/env-config';
 import * as bitcoin from 'bitcoinjs-lib';
 import { BIP32Factory } from 'bip32';
 import bs58check from 'bs58check';
@@ -262,9 +262,10 @@ export async function createInvoice(
   const expires = Math.floor(Date.now() / 1000) + 15 * 60;
   let address = BTC_WALLET_ADDRESS;
   let idx: number | null = null;
-  if (BTC_XPUB) {
+  const extPub = BTC_XPUB || BTC_ZPUB;
+  if (extPub) {
     idx = reserveAddressIndex();
-    const node = bip32.fromBase58(normalizeXpub(BTC_XPUB), bitcoin.networks.bitcoin);
+    const node = bip32.fromBase58(normalizeXpub(extPub), bitcoin.networks.bitcoin);
     const child = node.derive(0).derive(idx);
     address = bitcoin.payments.p2wpkh({ pubkey: Buffer.from(child.publicKey), network: bitcoin.networks.bitcoin }).address!;
   }


### PR DESCRIPTION
## Summary
- allow BTC_ZPUB in env-config
- generate invoices from BTC_ZPUB or BTC_XPUB
- document BTC_ZPUB usage in README and `.env.example`
- adjust unit tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68468e30afe08326ac3a0ec690a7ab35