### PR TITLE
Improve payment verification flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ Free users cannot monitor profiles. Premium users can monitor up to **5** profil
 
 ### Manual Payment Verification
 
-If your upgrade payment is not confirmed within an hour, you can verify it manually. Obtain the transaction hash (TXID) from your wallet and run:
+After sending your upgrade payment, you can speed up confirmation by verifying it manually.
+Obtain the transaction hash (TXID) from your wallet and run:
 
 ```
 /verify <txid>

--- a/src/controllers/upgrade.ts
+++ b/src/controllers/upgrade.ts
@@ -24,6 +24,8 @@ export async function handleUpgrade(ctx: IContextBot): Promise<void> {
       invoice.user_address,
       '```',
       'Reply with the address you will pay from within one hour.',
+      'After payment you can run `/verify <txid>` to speed up confirmation.',
+      'The txid is found in your wallet\'s transaction details.',
     ].join('\n');
     await ctx.reply(msg, { parse_mode: 'Markdown' });
   } catch (e) {

--- a/src/services/premium-service.ts
+++ b/src/services/premium-service.ts
@@ -62,7 +62,12 @@ export const removePremiumUser = (telegramId: string): void => {
 };
 
 export const extendPremium = (telegramId: string, days: number): void => {
-  const until = Math.floor(Date.now() / 1000) + days * 86400;
+  const row = db
+    .prepare('SELECT premium_until FROM users WHERE telegram_id = ?')
+    .get(telegramId) as UserRow | undefined;
+  const current = row?.premium_until || 0;
+  const base = current > Math.floor(Date.now() / 1000) ? current : Math.floor(Date.now() / 1000);
+  const until = base + days * 86400;
   db.prepare(
     `UPDATE users SET is_premium = 1, premium_until = ? WHERE telegram_id = ?`
   ).run(until, telegramId);


### PR DESCRIPTION
## Summary
- update invoice instructions to tell users about `/verify <txid>`
- extend premium days instead of resetting expiration
- tweak README payment verification section

## Testing
- `yarn install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68469427b380832692fe9e832fcea8d7