### PR TITLE
Update premium pinned message after payment

### DIFF
--- a/__mocks__/p-limit.js
+++ b/__mocks__/p-limit.js
@@ -1,0 +1,3 @@
+module.exports = function pLimit() {
+  return async (fn, ...args) => fn(...args);
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
     '^repositories/(.*)$': '<rootDir>/src/repositories/$1',
     '^types$': '<rootDir>/src/types.ts',
     '^index$': '<rootDir>/src/index.ts',
+    'p-limit': '<rootDir>/__mocks__/p-limit.js',
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,6 +284,14 @@ bot.command('verify', async (ctx) => {
     if (ctx.session?.upgrade && ctx.session.upgrade.invoice.id === invoice.id) {
       ctx.session.upgrade = undefined;
     }
+    const days = getPremiumDaysLeft(String(ctx.from.id));
+    await updatePremiumPinnedMessage(
+      bot,
+      ctx.chat!.id,
+      String(ctx.from.id),
+      days,
+      true,
+    );
     return ctx.reply('✅ Payment verified! Premium extended by 30 days.');
   }
   await ctx.reply('❌ Unable to verify this transaction.');

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -79,10 +79,11 @@ export async function updatePremiumPinnedMessage(
   chatId: number | string,
   telegramId: string,
   daysLeft: number,
+  force = false,
 ): Promise<void> {
   const lastUpdated = getPinnedMessageUpdatedAt(telegramId);
   const now = Math.floor(Date.now() / 1000);
-  if (lastUpdated && now - lastUpdated < 86400) {
+  if (!force && lastUpdated && now - lastUpdated < 86400) {
     return;
   }
   const daysText = daysLeft === Infinity ? 'unlimited' : daysLeft.toString();

--- a/src/services/btc-payment.ts
+++ b/src/services/btc-payment.ts
@@ -20,7 +20,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import { BIP32Factory } from 'bip32';
 import bs58check from 'bs58check';
 import * as ecc from 'tiny-secp256k1';
-import { extendPremium } from './premium-service';
+import { extendPremium, getPremiumDaysLeft } from './premium-service';
 import type { Telegraf } from 'telegraf';
 const bip32 = BIP32Factory(ecc);
 
@@ -102,8 +102,21 @@ function scheduleInvoiceCheck(
 
     if (newInv && newInv.paid_at) {
       extendPremium(userId, 30);
-      if (botInstance)
-        await botInstance.telegram.sendMessage(userId, '✅ Payment received! Premium extended by 30 days.');
+      if (botInstance) {
+        await botInstance.telegram.sendMessage(
+          userId,
+          '✅ Payment received! Premium extended by 30 days.',
+        );
+        const { updatePremiumPinnedMessage } = await import('lib');
+        const days = getPremiumDaysLeft(userId);
+        await updatePremiumPinnedMessage(
+          botInstance,
+          userId,
+          userId,
+          days,
+          true,
+        );
+      }
       deletePaymentCheck(invoice.id);
       paymentTimers.delete(invoice.id);
       if (reminderTimers.has(invoice.id)) {


### PR DESCRIPTION
## Summary
- update pinned message helper to allow forced update
- force pinned message update on successful payment
- stub `p-limit` for Jest and map in config

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx --yes jest`

------
https://chatgpt.com/codex/tasks/task_e_6846a216dc4c8326a902d3f39e775935