### PR TITLE
Clarify payment upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Obtain the transaction hash (TXID) from your wallet and run:
 ```
 
 The bot will check the blockchain immediately and credit Premium time if the amount matches.
+The TXID (sometimes called transaction hash) looks like `2d339983a78206050b4d70c15c5e14a3553438b25caedebdf2bb2f7162e33d59`.
 
 ## Development
 

--- a/src/controllers/upgrade.ts
+++ b/src/controllers/upgrade.ts
@@ -64,9 +64,9 @@ export async function handleUpgrade(ctx: IContextBot): Promise<void> {
       '```',
       invoice.user_address,
       '```',
-      'Reply with the address you will pay from within one hour.',
-      'Once paid, confirm by running `/verify <txid>`.',
-      'The txid is found in your wallet\'s transaction details.',
+      'Once paid, run `/verify <txid>` within one hour to confirm.',
+      "The txid (transaction hash) is shown in your wallet's transaction details.",
+      'Example: `2d339983a78206050b4d70c15c5e14a3553438b25caedebdf2bb2f7162e33d59`',
     ].join('\n');
     await sendTemporaryMessage(
       bot,


### PR DESCRIPTION
## Summary
- clarify that users don't need to send their wallet address after `/upgrade`
- show what a TXID looks like in README

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6846a8228fe08326bc85486ee2e5e74b