### PR TITLE
Add abuse prevention limits

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -79,3 +79,24 @@ export const getProfileRequestCooldownRemainingFx = createEffect(
       params.hours,
     ),
 );
+
+export const recordUserRequestFx = createEffect((telegram_id: string) =>
+  db.recordUserRequest(telegram_id),
+);
+
+export const countRecentUserRequestsFx = createEffect(
+  (params: { telegram_id: string; window: number }) =>
+    db.countRecentUserRequests(params.telegram_id, params.window),
+);
+
+export const countPendingJobsFx = createEffect((telegram_id: string) =>
+  db.countPendingJobs(telegram_id),
+);
+
+export const getLastVerifyAttemptFx = createEffect((telegram_id: string) =>
+  db.getLastVerifyAttempt(telegram_id),
+);
+
+export const updateVerifyAttemptFx = createEffect((telegram_id: string) =>
+  db.updateVerifyAttempt(telegram_id),
+);


### PR DESCRIPTION
## Summary
- add tables to store request history and verify attempts
- implement request counters and cooldown checks
- enforce rate limits and queue quotas in the queue manager
- throttle repeated `/verify` calls
- test new rate limit behavior
- allow admin to bypass these limits

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6846aedfd0908326bc3bad241815062e