### PR TITLE
Handle paginated jobs with lower priority

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -11,9 +11,19 @@ import { DownloadQueueItem, UserInfo } from 'types';
 // =========================================================================
 export const enqueueDownloadFx = createEffect(
   async (
-    params: { telegram_id: string; target_username: string; task_details: UserInfo },
+    params: {
+      telegram_id: string;
+      target_username: string;
+      task_details: UserInfo;
+      delaySeconds?: number;
+    },
   ): Promise<number> => {
-    return db.enqueueDownload(params.telegram_id, params.target_username, params.task_details);
+    return db.enqueueDownload(
+      params.telegram_id,
+      params.target_username,
+      params.task_details,
+      params.delaySeconds ?? 0,
+    );
   },
 );
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -186,8 +186,9 @@ export function enqueueDownload(
   telegram_id: string,
   target_username: string,
   task_details: UserInfo,
+  delaySeconds = 0,
 ): number {
-  const now = Math.floor(Date.now() / 1000);
+  const now = Math.floor(Date.now() / 1000) + delaySeconds;
   const detailsJson = JSON.stringify(task_details); // Convert object to JSON string for storage.
 
   const stmt = db.prepare(`


### PR DESCRIPTION
## Summary
- allow enqueueing with an optional delay
- let paginated downloads bypass rate/pending limits
- push paginated jobs back by 60s
- update queue manager tests for new behaviour

## Testing
- `yarn install --immutable`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846b4cc3c588326a93aead293738068