### PR TITLE
Add verify instructions for repeated invoice

### DIFF
--- a/__tests__/upgrade-command.test.ts
+++ b/__tests__/upgrade-command.test.ts
@@ -69,6 +69,7 @@ describe('upgrade command', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect(sendTemporaryMessage).toHaveBeenCalledTimes(2);
     expect(sendTemporaryMessage.mock.calls[1][2]).toContain('already generated');
+    expect(sendTemporaryMessage.mock.calls[1][2]).toContain('/verify <txid>');
     spy.mockRestore();
   });
 });

--- a/src/controllers/upgrade.ts
+++ b/src/controllers/upgrade.ts
@@ -39,6 +39,9 @@ export async function handleUpgrade(ctx: IContextBot): Promise<void> {
         state.invoice.user_address,
         '```',
         `Invoice expires in ${mins} minute${mins === 1 ? '' : 's'}.`,
+        'Once paid, run `/verify <txid>` within one hour to confirm.',
+        "The txid (transaction hash) is shown in your wallet's transaction details.",
+        'Example: `2d339983a78206050b4d70c15c5e14a3553438b25caedebdf2bb2f7162e33d59`',
       ].join('\n');
       await sendTemporaryMessage(
         bot,


### PR DESCRIPTION
## Summary
- remind users how to verify payment if they reused a previous invoice
- test that the repeat invoice message mentions `/verify <txid>`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68471925bce48326a092c1c3d07afb03