### PR TITLE
Fix story link validation

### DIFF
--- a/__tests__/story-link-validation.test.ts
+++ b/__tests__/story-link-validation.test.ts
@@ -1,0 +1,16 @@
+jest.mock('../src/config/env-config', () => ({ BOT_ADMIN_ID: 0, BOT_TOKEN: 't', LOG_FILE: '/tmp/test.log' }));
+
+import { isValidStoryLink } from '../src/lib/helpers';
+
+describe('isValidStoryLink', () => {
+  test('accepts valid t.me links', () => {
+    expect(isValidStoryLink('https://t.me/user/s/123')).toBe(true);
+    expect(isValidStoryLink('t.me/user/s/456')).toBe(true);
+    expect(isValidStoryLink('https://telegram.me/user/s/789')).toBe(true);
+  });
+
+  test('rejects non-telegram links', () => {
+    expect(isValidStoryLink('https://example.com/user/s/123')).toBe(false);
+    expect(isValidStoryLink('http://telegram.me.user/s/789')).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,12 @@ import { handleUpgrade } from 'controllers/upgrade';
 import { handlePremium } from 'controllers/premium';
 import { sendProfileMedia } from 'controllers/send-profile-media';
 import { UserInfo } from 'types';
-import { sendTemporaryMessage, updatePremiumPinnedMessage, isValidBitcoinAddress } from 'lib';
+import {
+  sendTemporaryMessage,
+  updatePremiumPinnedMessage,
+  isValidBitcoinAddress,
+  isValidStoryLink,
+} from 'lib';
 import {
   recordProfileRequestFx,
   wasProfileRequestedRecentlyFx,
@@ -795,7 +800,7 @@ bot.on('text', async (ctx) => {
     return;
   }
 
-  const isStoryLink = text.startsWith('https') || text.startsWith('t.me/');
+  const isStoryLink = isValidStoryLink(text);
   const isUsername = text.startsWith('@') || text.startsWith('+');
 
   if (isUsername || isStoryLink) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -123,3 +123,14 @@ export function isValidBitcoinAddress(address: string): boolean {
     return false;
   }
 }
+
+// Validate if a link matches the Telegram story URL format.
+// Accepted formats:
+//   https://t.me/username/s/123
+//   http://t.me/username/s/123
+//   t.me/username/s/123
+export function isValidStoryLink(link: string): boolean {
+  return /^(?:https?:\/\/)?(?:t\.me|telegram\.me)\/[^\/]+\/s\/\d+\/?$/i.test(
+    link.trim(),
+  );
+}


### PR DESCRIPTION
## Summary
- validate Telegram story links before queueing tasks
- add `isValidStoryLink` helper
- test story link validation

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68471cb49d3c83269dc0fe52a75e35e2