### PR TITLE
Fix help menu newline escaping

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -90,9 +90,9 @@
   "referral.fiveUsers": "🎉 You referred 5 users! Premium extended by 7 days.",
   "referral.paid": "🎉 Your referral made a payment! Premium extended by 30 days.",
   "help.header": "*Ghost Stories Bot Help*",
-  "help.general": "*General Commands:*\\n`/start` - {{cmdStart}}\\n`/help` - {{cmdHelp}}\\n`/premium` - {{cmdPremium}}\\n`/freetrial` - {{cmdFreetrial}}\\n`/queue` - {{cmdQueue}}\\n`/invite` - {{cmdInvite}}\\n`/profile` - {{cmdProfile}}\\n`/verify <txid>` - {{cmdVerify}}",
-  "help.premium": "*Premium Commands:*\\n`/monitor` - {{cmdMonitor}}\\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Admin Commands:*\\n`/setpremium <ID or @username> [days]` - {{cmdSetpremium}} (0 = {{neverExpires}})\\n`/unsetpremium <ID or @username>` - {{cmdUnsetpremium}}\\n`/ispremium <ID or @username>` - {{cmdIspremium}}\\n`/listpremium` - {{cmdListpremium}}\\n`/users` - {{cmdUsers}}\\n`/history` - {{cmdHistory}}\\n`/block <ID or @username>` - {{cmdBlock}}\\n`/unblock <ID or @username>` - {{cmdUnblock}}\\n`/blocklist` - {{cmdBlocklist}}\\n`/restart` - {{cmdRestart}}",
+  "help.general": "*General Commands:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
+  "help.premium": "*Premium Commands:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
+  "help.admin": "*Admin Commands:*\n`/setpremium <ID or @username> [days]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID or @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID or @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID or @username>` - {{cmdBlock}}\n`/unblock <ID or @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
   "help.txidInfo": "To find the transaction ID (txid), check the details of your payment in your wallet.",
   "error.unexpected": "Sorry, an unexpected error occurred. Please try again later."
 }


### PR DESCRIPTION
## Summary
- fix newline escaping in English help text

## Testing
- `bash setup.sh`
- `yarn test`
- `yarn lint` *(fails: ESLint couldn't find eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68472dad6bd883268c61801520a92fa4