### PR TITLE
Remove redundant TXID note from help message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,7 +302,6 @@ bot.command('help', async (ctx) => {
         neverExpires: t(locale, 'premium.neverExpires'),
       });
   }
-  finalHelpText += '\n' + t(locale, 'help.txidInfo');
   await ctx.reply(finalHelpText, { parse_mode: 'Markdown' });
   await updateUserCommands(ctx, isAdmin, isPremium);
 });

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -93,6 +93,5 @@
   "help.general": "*الأوامر العامة:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*أوامر البريميوم:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*أوامر المشرف:*\n`/setpremium <ID أو @username> [أيام]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID أو @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID أو @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID أو @username>` - {{cmdBlock}}\n`/unblock <ID أو @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "للعثور على معرف المعاملة (txid)، تحقق من تفاصيل الدفع في محفظتك.",
   "error.unexpected": "عذرًا، حدث خطأ غير متوقع. يرجى المحاولة لاحقًا."
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -93,6 +93,5 @@
   "help.general": "*Allgemeine Befehle:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Premium-Befehle:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Admin-Befehle:*\n`/setpremium <ID oder @username> [Tage]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID oder @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID oder @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID oder @username>` - {{cmdBlock}}\n`/unblock <ID oder @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Um die Transaktions-ID (txid) zu finden, überprüfe die Zahlungsdetails in deiner Wallet.",
   "error.unexpected": "Entschuldigung, ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -93,6 +93,5 @@
   "help.general": "*General Commands:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Premium Commands:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Admin Commands:*\n`/setpremium <ID or @username> [days]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID or @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID or @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID or @username>` - {{cmdBlock}}\n`/unblock <ID or @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "To find the transaction ID (txid), check the details of your payment in your wallet.",
   "error.unexpected": "Sorry, an unexpected error occurred. Please try again later."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -93,6 +93,5 @@
   "help.general": "*Comandos generales:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Comandos premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Comandos de administrador:*\n`/setpremium <ID o @usuario> [días]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @usuario>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @usuario>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @usuario>` - {{cmdBlock}}\n`/unblock <ID o @usuario>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Para encontrar el ID de transacción (txid), revisa los detalles de tu pago en la cartera.",
   "error.unexpected": "Lo sentimos, ocurrió un error inesperado. Por favor, inténtalo de nuevo más tarde."
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -93,6 +93,5 @@
   "help.general": "*Commandes générales:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Commandes premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Commandes admin:*\n`/setpremium <ID ou @username> [jours]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Pour trouver l'identifiant de transaction (txid), vérifiez les détails du paiement dans votre portefeuille.",
   "error.unexpected": "Désolé, une erreur inattendue est survenue. Veuillez réessayer plus tard."
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -93,6 +93,5 @@
   "help.general": "*Comandi generali:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Comandi premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Comandi admin:*\n`/setpremium <ID o @username> [giorni]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @username>` - {{cmdBlock}}\n`/unblock <ID o @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Per trovare l'ID della transazione (txid), controlla i dettagli del pagamento nel tuo wallet.",
   "error.unexpected": "Spiacenti, si è verificato un errore imprevisto. Riprova più tardi."
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -93,6 +93,5 @@
   "help.general": "*일반 명령:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*프리미엄 명령:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*관리자 명령:*\n`/setpremium <ID 또는 @username> [일]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 또는 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 또는 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 또는 @username>` - {{cmdBlock}}\n`/unblock <ID 또는 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "거래 ID(txid)를 찾으려면 지갑에서 결제 세부 정보를 확인하세요.",
   "error.unexpected": "죄송합니다. 예상치 못한 오류가 발생했습니다. 나중에 다시 시도해주세요."
 }

--- a/src/locales/ms.json
+++ b/src/locales/ms.json
@@ -93,6 +93,5 @@
   "help.general": "*Arahan umum:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Arahan premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Arahan pentadbir:*\n`/setpremium <ID atau @username> [hari]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID atau @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID atau @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID atau @username>` - {{cmdBlock}}\n`/unblock <ID atau @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Untuk mencari ID transaksi (txid), semak butiran pembayaran dalam dompet anda.",
   "error.unexpected": "Maaf, ralat tidak dijangka berlaku. Sila cuba lagi nanti."
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -93,6 +93,5 @@
   "help.general": "*Algemene commando's:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Premiumcommando's:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Beheercommando's:*\n`/setpremium <ID of @username> [dagen]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID of @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID of @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID of @username>` - {{cmdBlock}}\n`/unblock <ID of @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Om de transactie-ID (txid) te vinden, bekijk de details van je betaling in je wallet.",
   "error.unexpected": "Er is een onverwachte fout opgetreden. Probeer het later opnieuw."
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -93,6 +93,5 @@
   "help.general": "*Comandos gerais:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Comandos premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Comandos de admin:*\n`/setpremium <ID ou @username> [dias]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Para encontrar o ID da transação (txid), verifique os detalhes do pagamento na sua carteira.",
   "error.unexpected": "Desculpe, ocorreu um erro inesperado. Tente novamente mais tarde."
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -93,6 +93,5 @@
   "help.general": "*Общие команды:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Премиум-команды:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Команды администратора:*\n`/setpremium <ID или @username> [дней]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID или @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID или @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID или @username>` - {{cmdBlock}}\n`/unblock <ID или @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Чтобы найти идентификатор транзакции (txid), проверьте детали платежа в своем кошельке.",
   "error.unexpected": "Извините, произошла непредвиденная ошибка. Пожалуйста, попробуйте позже."
 }

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -93,6 +93,5 @@
   "help.general": "*Загальні команди:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Преміум-команди:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*Адмін-команди:*\n`/setpremium <ID або @username> [днів]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID або @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID або @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID або @username>` - {{cmdBlock}}\n`/unblock <ID або @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "Щоб знайти ID транзакції (txid), перевірте деталі платежу у вашому гаманці.",
   "error.unexpected": "Вибачте, сталася непередбачена помилка. Спробуйте пізніше."
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -93,6 +93,5 @@
   "help.general": "*常用命令：*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*高级命令：*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
   "help.admin": "*管理员命令：*\n`/setpremium <ID 或 @username> [天]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 或 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 或 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 或 @username>` - {{cmdBlock}}\n`/unblock <ID 或 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
-  "help.txidInfo": "要查找交易 ID (txid)，请在钱包中查看付款详情。",
   "error.unexpected": "抱歉，发生意外错误。请稍后再试。"
 }


### PR DESCRIPTION
## Summary
- drop unused help.txidInfo field from all locales
- stop appending this text in the /help command

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684730e4ece0832686a0a7031ede8317