### PR TITLE
Add admin restart stats

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -110,3 +110,16 @@ export const getLastVerifyAttemptFx = createEffect((telegram_id: string) =>
 export const updateVerifyAttemptFx = createEffect((telegram_id: string) =>
   db.updateVerifyAttempt(telegram_id),
 );
+
+// Stats effect helpers
+export const countNewUsersSinceFx = createEffect((since: number) =>
+  db.countNewUsersSince(since),
+);
+
+export const countPaymentsSinceFx = createEffect((since: number) =>
+  db.countPaymentsSince(since),
+);
+
+export const countReferralsSinceFx = createEffect((since: number) =>
+  db.countReferralsSince(since),
+);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -805,3 +805,28 @@ export function getSuspensionRemaining(telegram_id: string): number {
 export function isUserTemporarilySuspended(telegram_id: string): boolean {
   return getSuspensionRemaining(telegram_id) > 0;
 }
+
+// ====== Stats helpers ======
+
+export function countNewUsersSince(since: number): number {
+  const row = db
+    .prepare("SELECT COUNT(*) as c FROM users WHERE strftime('%s', created_at) > ?")
+    .get(since) as { c: number } | undefined;
+  return row?.c || 0;
+}
+
+export function countPaymentsSince(since: number): number {
+  const row = db
+    .prepare(
+      "SELECT COUNT(*) as c FROM payments WHERE paid_at IS NOT NULL AND paid_at > ?",
+    )
+    .get(since) as { c: number } | undefined;
+  return row?.c || 0;
+}
+
+export function countReferralsSince(since: number): number {
+  const row = db
+    .prepare("SELECT COUNT(*) as c FROM referrals WHERE created_at > ?")
+    .get(since) as { c: number } | undefined;
+  return row?.c || 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import {
   setBotInstance,
   verifyPaymentByTxid,
 } from './services/btc-payment';
+import { startAdminStatusUpdates } from './services/admin-stats';
 import { handleUpgrade } from 'controllers/upgrade';
 import { handlePremium } from 'controllers/premium';
 import { sendProfileMedia } from 'controllers/send-profile-media';
@@ -872,6 +873,7 @@ async function startApp() {
   );
   bot.launch({ dropPendingUpdates: true }).then(() => {
     console.log('✅ Telegram bot started successfully and is ready for commands.');
+    startAdminStatusUpdates(bot);
   });
 }
 

--- a/src/services/admin-stats.ts
+++ b/src/services/admin-stats.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import { Telegraf } from 'telegraf';
+import { BOT_ADMIN_ID, LOG_FILE } from '../config/env-config';
+import { db } from '../db';
+
+let startTimestamp = Math.floor(Date.now() / 1000);
+let statusMessageId: number | null = null;
+
+function countRows(query: string, param: number): number {
+  const row = db.prepare(query).get(param) as { c: number } | undefined;
+  return row?.c || 0;
+}
+
+export function getDailyStats() {
+  const since = Math.floor(Date.now() / 1000) - 86400;
+  const newUsers = countRows(
+    "SELECT COUNT(*) as c FROM users WHERE strftime('%s', created_at) > ?",
+    since,
+  );
+  const paidInvoices = countRows(
+    "SELECT COUNT(*) as c FROM payments WHERE paid_at IS NOT NULL AND paid_at > ?",
+    since,
+  );
+  const invitesRedeemed = countRows(
+    "SELECT COUNT(*) as c FROM referrals WHERE created_at > ?",
+    since,
+  );
+
+  let errors = 0;
+  try {
+    const dayAgo = Date.now() - 86400 * 1000;
+    const lines = fs.readFileSync(LOG_FILE, 'utf8').split('\n');
+    for (const line of lines) {
+      const m = line.match(/^\[(.+?)\]/);
+      if (m) {
+        const ts = Date.parse(m[1]);
+        if (ts && ts > dayAgo) errors++;
+      }
+    }
+  } catch {}
+
+  return { newUsers, paidInvoices, invitesRedeemed, errors };
+}
+
+function formatUptime(): string {
+  const seconds = Math.floor(Date.now() / 1000) - startTimestamp;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+export async function sendStartupStatus(bot: Telegraf<any>) {
+  startTimestamp = Math.floor(Date.now() / 1000);
+  const stats = getDailyStats();
+  const text =
+    `✅ Bot restarted\n` +
+    `New users: ${stats.newUsers}\n` +
+    `Payments: ${stats.paidInvoices}\n` +
+    `Invites redeemed: ${stats.invitesRedeemed}\n` +
+    `Errors last 24h: ${stats.errors}`;
+  const msg = await bot.telegram.sendMessage(BOT_ADMIN_ID, text);
+  try {
+    await bot.telegram.pinChatMessage(BOT_ADMIN_ID, msg.message_id, {
+      disable_notification: true,
+    });
+  } catch {}
+  statusMessageId = msg.message_id;
+}
+
+export async function updateAdminStatus(bot: Telegraf<any>) {
+  if (!statusMessageId) return;
+  const stats = getDailyStats();
+  const text =
+    `🕒 Uptime: ${formatUptime()}\n` +
+    `New users: ${stats.newUsers}\n` +
+    `Payments: ${stats.paidInvoices}\n` +
+    `Invites redeemed: ${stats.invitesRedeemed}\n` +
+    `Errors last 24h: ${stats.errors}`;
+  try {
+    await bot.telegram.editMessageText(
+      BOT_ADMIN_ID,
+      statusMessageId,
+      undefined,
+      text,
+    );
+  } catch {}
+}
+
+export function startAdminStatusUpdates(bot: Telegraf<any>) {
+  sendStartupStatus(bot);
+  setInterval(() => updateAdminStatus(bot), 60 * 60 * 1000);
+}
+


### PR DESCRIPTION
## Summary
- show admin usage summary on startup
- schedule hourly status updates
- expose stat helpers in DB

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6847463d61f883268440f5689f644501