### PR TITLE
Add uptime to admin pinned status

### DIFF
--- a/__tests__/admin-stats.test.ts
+++ b/__tests__/admin-stats.test.ts
@@ -1,0 +1,70 @@
+import { jest } from '@jest/globals';
+
+process.env.NODE_ENV = 'test';
+process.env.STATUS_ID_FILE = '/tmp/admin-status-id';
+
+jest.mock('../src/config/env-config', () => ({
+  BOT_ADMIN_ID: 0,
+  BOT_TOKEN: 'token',
+  LOG_FILE: '/tmp/test.log',
+}));
+
+jest.mock('../src/db', () => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE users (created_at TEXT);
+    CREATE TABLE payments (paid_at INTEGER);
+    CREATE TABLE referrals (created_at INTEGER);
+  `);
+  return { db };
+});
+
+import fs from 'fs';
+import { sendStartupStatus, updateAdminStatus } from '../src/services/admin-stats';
+
+const telegram: any = {
+  sendMessage: jest.fn(() => Promise.resolve({ message_id: 1 })),
+  pinChatMessage: jest.fn(),
+  editMessageText: jest.fn(),
+  unpinChatMessage: jest.fn(() => Promise.resolve()),
+};
+const bot: any = { telegram };
+
+describe('admin stats status message', () => {
+  beforeEach(() => {
+    telegram.sendMessage.mockClear();
+    telegram.pinChatMessage.mockClear();
+    telegram.editMessageText.mockClear();
+    telegram.unpinChatMessage.mockClear();
+    fs.writeFileSync('/tmp/test.log', '');
+    try {
+      fs.unlinkSync('/tmp/admin-status-id');
+    } catch {}
+  });
+
+  test('sends startup status with uptime and pins message', async () => {
+    fs.writeFileSync('/tmp/admin-status-id', '9');
+    await sendStartupStatus(bot);
+    expect(telegram.sendMessage).toHaveBeenCalledWith(
+      0,
+      expect.stringContaining('Uptime: 0h 0m'),
+    );
+    expect(telegram.unpinChatMessage).toHaveBeenCalledWith(0, 9);
+    expect(telegram.pinChatMessage).toHaveBeenCalledWith(0, 1, {
+      disable_notification: true,
+    });
+  });
+
+  test('updates status message', async () => {
+    await sendStartupStatus(bot);
+    telegram.editMessageText.mockClear();
+    await updateAdminStatus(bot);
+    expect(telegram.editMessageText).toHaveBeenCalledWith(
+      0,
+      1,
+      undefined,
+      expect.stringContaining('Uptime:'),
+    );
+  });
+});

--- a/src/services/admin-stats.ts
+++ b/src/services/admin-stats.ts
@@ -1,10 +1,30 @@
 import fs from 'fs';
+import path from 'path';
 import { Telegraf } from 'telegraf';
 import { BOT_ADMIN_ID, LOG_FILE } from '../config/env-config';
 import { db } from '../db';
 
 let startTimestamp = Math.floor(Date.now() / 1000);
 let statusMessageId: number | null = null;
+const STATUS_ID_FILE =
+  process.env.STATUS_ID_FILE ||
+  path.join(__dirname, '../../data/admin_status_id');
+
+function readSavedStatusId(): number | null {
+  try {
+    const id = fs.readFileSync(STATUS_ID_FILE, 'utf8');
+    return Number(id) || null;
+  } catch {
+    return null;
+  }
+}
+
+function saveStatusId(id: number) {
+  try {
+    fs.mkdirSync(path.dirname(STATUS_ID_FILE), { recursive: true });
+    fs.writeFileSync(STATUS_ID_FILE, String(id));
+  } catch {}
+}
 
 function countRows(query: string, param: number): number {
   const row = db.prepare(query).get(param) as { c: number } | undefined;
@@ -51,23 +71,31 @@ function formatUptime(): string {
 
 export async function sendStartupStatus(bot: Telegraf<any>) {
   startTimestamp = Math.floor(Date.now() / 1000);
+  const prev = readSavedStatusId();
   const stats = getDailyStats();
   const text =
-    `✅ Bot restarted\n` +
+    `🕒 Uptime: ${formatUptime()}\n` +
     `New users: ${stats.newUsers}\n` +
     `Payments: ${stats.paidInvoices}\n` +
     `Invites redeemed: ${stats.invitesRedeemed}\n` +
     `Errors last 24h: ${stats.errors}`;
   const msg = await bot.telegram.sendMessage(BOT_ADMIN_ID, text);
   try {
+    if (prev) {
+      await bot.telegram.unpinChatMessage(BOT_ADMIN_ID, prev).catch(() => {});
+    }
     await bot.telegram.pinChatMessage(BOT_ADMIN_ID, msg.message_id, {
       disable_notification: true,
     });
   } catch {}
   statusMessageId = msg.message_id;
+  saveStatusId(msg.message_id);
 }
 
 export async function updateAdminStatus(bot: Telegraf<any>) {
+  if (!statusMessageId) {
+    statusMessageId = readSavedStatusId();
+  }
   if (!statusMessageId) return;
   const stats = getDailyStats();
   const text =


### PR DESCRIPTION
## Summary
- include uptime in the admin startup status message and keep it pinned using a persistent ID file
- avoid unpinning the premium status pin
- unit test updates for new pin persistence logic

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68474f7d38888326b395b50fde9373a2