### PR TITLE
Fix self-blocking bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ if (!fs.existsSync(logDir)) {
 bot.use(session());
 bot.use(async (ctx, next) => {
   if (ctx.from?.is_bot) {
-    if (ctx.from.id) {
+    if (ctx.from.id && ctx.from.id !== bot.botInfo?.id) {
       blockUser(String(ctx.from.id), true);
     }
     return;

--- a/src/services/admin-stats.ts
+++ b/src/services/admin-stats.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { Telegraf } from 'telegraf';
 import { BOT_ADMIN_ID, LOG_FILE } from '../config/env-config';
-import { db } from '../db';
+import { db, unblockUser } from '../db';
 
 let startTimestamp = Math.floor(Date.now() / 1000);
 let statusMessageId: number | null = null;
@@ -80,6 +80,9 @@ export async function sendStartupStatus(bot: Telegraf<any>) {
     `Invites redeemed: ${stats.invitesRedeemed}\n` +
     `Errors last 24h: ${stats.errors}`;
   const msg = await bot.telegram.sendMessage(BOT_ADMIN_ID, text);
+  if (bot.botInfo?.id) {
+    unblockUser(String(bot.botInfo.id));
+  }
   try {
     if (prev) {
       await bot.telegram.unpinChatMessage(BOT_ADMIN_ID, prev).catch(() => {});


### PR DESCRIPTION
## Summary
- avoid blocking messages sent by the bot itself
- remove bot id from blocklist when sending admin startup status

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684754efa4748326a83b7645825200be