### PR TITLE
Implement manual status command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import {
   setBotInstance,
   verifyPaymentByTxid,
 } from './services/btc-payment';
-import { startAdminStatusUpdates } from './services/admin-stats';
+import { getStatusText } from './services/admin-stats';
 import { handleUpgrade } from 'controllers/upgrade';
 import { handlePremium } from 'controllers/premium';
 import { sendProfileMedia } from 'controllers/send-profile-media';
@@ -121,6 +121,7 @@ function getAdminCommands(locale: string) {
     { command: 'block', description: t(locale, 'cmd.block') },
     { command: 'unblock', description: t(locale, 'cmd.unblock') },
     { command: 'blocklist', description: t(locale, 'cmd.blocklist') },
+    { command: 'status', description: t(locale, 'cmd.status') },
     { command: 'restart', description: t(locale, 'cmd.restart') },
   ];
 }
@@ -509,6 +510,12 @@ bot.command('unmonitor', async (ctx) => {
 
 // --- Admin Commands ---
 
+bot.command('status', async (ctx) => {
+  if (ctx.from.id != BOT_ADMIN_ID) return;
+  const text = getStatusText();
+  await ctx.reply(text);
+});
+
 bot.command('restart', async (ctx) => {
   if (ctx.from.id != BOT_ADMIN_ID) return;
   const locale = ctx.from.language_code || 'en';
@@ -877,7 +884,6 @@ async function startApp() {
   );
   bot.launch({ dropPendingUpdates: true }).then(() => {
     console.log('✅ Telegram bot started successfully and is ready for commands.');
-    startAdminStatusUpdates(bot);
   });
 }
 

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -23,6 +23,7 @@
   "cmd.block": "منع المستخدم",
   "cmd.unblock": "إلغاء حظر المستخدم",
   "cmd.blocklist": "قائمة المستخدمين المحظورة",
+  "cmd.status": "عرض حالة الروبوت",
   "cmd.restart": "أعد تشغيل الروبوت",
   "msg.startFirst": "الرجاء الكتابة /البدء أولاً.",
   "msg.botStart": "👋 يرجى الكتابة /البدء في البدء في استخدام الروبوت.",
@@ -92,6 +93,6 @@
   "help.header": "*مساعدة بوت القصص الشبحية*",
   "help.general": "*الأوامر العامة:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*أوامر البريميوم:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*أوامر المشرف:*\n`/setpremium <ID أو @username> [أيام]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID أو @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID أو @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID أو @username>` - {{cmdBlock}}\n`/unblock <ID أو @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*أوامر المشرف:*\n`/setpremium <ID أو @username> [أيام]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID أو @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID أو @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID أو @username>` - {{cmdBlock}}\n`/unblock <ID أو @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "عذرًا، حدث خطأ غير متوقع. يرجى المحاولة لاحقًا."
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -23,6 +23,7 @@
   "cmd.block": "Benutzer blockieren",
   "cmd.unblock": "Blockierung aufheben",
   "cmd.blocklist": "Blockierte Benutzer",
+  "cmd.status": "Botstatus anzeigen",
   "cmd.restart": "Bot neu starten",
   "msg.startFirst": "Bitte zuerst /start eingeben.",
   "msg.botStart": "👋 Bitte mit /start beginnen.",
@@ -92,6 +93,6 @@
   "help.header": "*Hilfe für Ghost Stories Bot*",
   "help.general": "*Allgemeine Befehle:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Premium-Befehle:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Admin-Befehle:*\n`/setpremium <ID oder @username> [Tage]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID oder @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID oder @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID oder @username>` - {{cmdBlock}}\n`/unblock <ID oder @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Admin-Befehle:*\n`/setpremium <ID oder @username> [Tage]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID oder @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID oder @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID oder @username>` - {{cmdBlock}}\n`/unblock <ID oder @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Entschuldigung, ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,6 +23,7 @@
   "cmd.block": "Block a user",
   "cmd.unblock": "Unblock a user",
   "cmd.blocklist": "List blocked users",
+  "cmd.status": "Show bot status",
   "cmd.restart": "Restart the bot",
   "msg.startFirst": "Please type /start first.",
   "msg.botStart": "👋 Please type /start to begin using the bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Ghost Stories Bot Help*",
   "help.general": "*General Commands:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Premium Commands:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Admin Commands:*\n`/setpremium <ID or @username> [days]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID or @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID or @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID or @username>` - {{cmdBlock}}\n`/unblock <ID or @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Admin Commands:*\n`/setpremium <ID or @username> [days]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID or @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID or @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID or @username>` - {{cmdBlock}}\n`/unblock <ID or @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Sorry, an unexpected error occurred. Please try again later."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -23,6 +23,7 @@
   "cmd.block": "Bloquear usuario",
   "cmd.unblock": "Desbloquear usuario",
   "cmd.blocklist": "Usuarios bloqueados",
+  "cmd.status": "Mostrar estado del bot",
   "cmd.restart": "Reiniciar el bot",
   "msg.startFirst": "Por favor escribe /start primero.",
   "msg.botStart": "👋 Escribe /start para comenzar a usar el bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Ayuda de Ghost Stories Bot*",
   "help.general": "*Comandos generales:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Comandos premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Comandos de administrador:*\n`/setpremium <ID o @usuario> [días]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @usuario>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @usuario>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @usuario>` - {{cmdBlock}}\n`/unblock <ID o @usuario>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Comandos de administrador:*\n`/setpremium <ID o @usuario> [días]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @usuario>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @usuario>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @usuario>` - {{cmdBlock}}\n`/unblock <ID o @usuario>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Lo sentimos, ocurrió un error inesperado. Por favor, inténtalo de nuevo más tarde."
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -23,6 +23,7 @@
   "cmd.block": "Bloquer un utilisateur",
   "cmd.unblock": "Débloquer un utilisateur",
   "cmd.blocklist": "Utilisateurs bloqués",
+  "cmd.status": "Afficher l'état du bot",
   "cmd.restart": "Redémarrer le bot",
   "msg.startFirst": "Veuillez d'abord taper /start.",
   "msg.botStart": "👋 Tapez /start pour commencer à utiliser le bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Aide du bot Ghost Stories*",
   "help.general": "*Commandes générales:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Commandes premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Commandes admin:*\n`/setpremium <ID ou @username> [jours]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Commandes admin:*\n`/setpremium <ID ou @username> [jours]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Désolé, une erreur inattendue est survenue. Veuillez réessayer plus tard."
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -23,6 +23,7 @@
   "cmd.block": "Block a user",
   "cmd.unblock": "Unblock a user",
   "cmd.blocklist": "List blocked users",
+  "cmd.status": "Show bot status",
   "cmd.restart": "Restart the bot",
   "msg.startFirst": "Please type /start first.",
   "msg.botStart": "👋 Please type /start to begin using the bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Guida di Ghost Stories Bot*",
   "help.general": "*Comandi generali:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Comandi premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Comandi admin:*\n`/setpremium <ID o @username> [giorni]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @username>` - {{cmdBlock}}\n`/unblock <ID o @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Comandi admin:*\n`/setpremium <ID o @username> [giorni]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @username>` - {{cmdBlock}}\n`/unblock <ID o @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Spiacenti, si è verificato un errore imprevisto. Riprova più tardi."
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -23,6 +23,7 @@
   "cmd.block": "사용자 차단",
   "cmd.unblock": "차단 해제",
   "cmd.blocklist": "차단 목록",
+  "cmd.status": "봇 상태 보기",
   "cmd.restart": "버튼 재시작",
   "msg.startFirst": "/start를 먼저 입력하세요.",
   "msg.botStart": "👋 /start를 입력하여 시작하세요.",
@@ -92,6 +93,6 @@
   "help.header": "*고스트 스토리 봇 도움말*",
   "help.general": "*일반 명령:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*프리미엄 명령:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*관리자 명령:*\n`/setpremium <ID 또는 @username> [일]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 또는 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 또는 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 또는 @username>` - {{cmdBlock}}\n`/unblock <ID 또는 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*관리자 명령:*\n`/setpremium <ID 또는 @username> [일]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 또는 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 또는 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 또는 @username>` - {{cmdBlock}}\n`/unblock <ID 또는 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "죄송합니다. 예상치 못한 오류가 발생했습니다. 나중에 다시 시도해주세요."
 }

--- a/src/locales/ms.json
+++ b/src/locales/ms.json
@@ -23,6 +23,7 @@
   "cmd.block": "Block a user",
   "cmd.unblock": "Unblock a user",
   "cmd.blocklist": "List blocked users",
+  "cmd.status": "Show bot status",
   "cmd.restart": "Restart the bot",
   "msg.startFirst": "Please type /start first.",
   "msg.botStart": "👋 Please type /start to begin using the bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Bantuan Bot Ghost Stories*",
   "help.general": "*Arahan umum:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Arahan premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Arahan pentadbir:*\n`/setpremium <ID atau @username> [hari]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID atau @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID atau @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID atau @username>` - {{cmdBlock}}\n`/unblock <ID atau @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Arahan pentadbir:*\n`/setpremium <ID atau @username> [hari]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID atau @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID atau @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID atau @username>` - {{cmdBlock}}\n`/unblock <ID atau @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Maaf, ralat tidak dijangka berlaku. Sila cuba lagi nanti."
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -23,6 +23,7 @@
   "cmd.block": "Block a user",
   "cmd.unblock": "Unblock a user",
   "cmd.blocklist": "List blocked users",
+  "cmd.status": "Show bot status",
   "cmd.restart": "Restart the bot",
   "msg.startFirst": "Please type /start first.",
   "msg.botStart": "👋 Please type /start to begin using the bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Ghost Stories Bot Hulp*",
   "help.general": "*Algemene commando's:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Premiumcommando's:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Beheercommando's:*\n`/setpremium <ID of @username> [dagen]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID of @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID of @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID of @username>` - {{cmdBlock}}\n`/unblock <ID of @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Beheercommando's:*\n`/setpremium <ID of @username> [dagen]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID of @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID of @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID of @username>` - {{cmdBlock}}\n`/unblock <ID of @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Er is een onverwachte fout opgetreden. Probeer het later opnieuw."
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -23,6 +23,7 @@
   "cmd.block": "Bloquear usuário",
   "cmd.unblock": "Desbloquear usuário",
   "cmd.blocklist": "Lista de bloqueados",
+  "cmd.status": "Mostrar status do bot",
   "cmd.restart": "Reiniciar bot",
   "msg.startFirst": "Por favor, digite /start primeiro.",
   "msg.botStart": "👋 Digite /start para começar a usar o bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Ajuda do Ghost Stories Bot*",
   "help.general": "*Comandos gerais:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Comandos premium:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Comandos de admin:*\n`/setpremium <ID ou @username> [dias]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Comandos de admin:*\n`/setpremium <ID ou @username> [dias]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Desculpe, ocorreu um erro inesperado. Tente novamente mais tarde."
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -23,6 +23,7 @@
   "cmd.block": "Заблокировать пользователя",
   "cmd.unblock": "Разблокировать пользователя",
   "cmd.blocklist": "Список заблокированных",
+  "cmd.status": "Показать статус бота",
   "cmd.restart": "Перезапустить бота",
   "msg.startFirst": "Пожалуйста, начните с /start.",
   "msg.botStart": "👋 Наберите /start, чтобы начать.",
@@ -92,6 +93,6 @@
   "help.header": "*Помощь бота Ghost Stories*",
   "help.general": "*Общие команды:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Премиум-команды:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Команды администратора:*\n`/setpremium <ID или @username> [дней]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID или @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID или @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID или @username>` - {{cmdBlock}}\n`/unblock <ID или @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Команды администратора:*\n`/setpremium <ID или @username> [дней]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID или @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID или @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID или @username>` - {{cmdBlock}}\n`/unblock <ID или @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Извините, произошла непредвиденная ошибка. Пожалуйста, попробуйте позже."
 }

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -23,6 +23,7 @@
   "cmd.block": "Block a user",
   "cmd.unblock": "Unblock a user",
   "cmd.blocklist": "List blocked users",
+  "cmd.status": "Show bot status",
   "cmd.restart": "Restart the bot",
   "msg.startFirst": "Please type /start first.",
   "msg.botStart": "👋 Please type /start to begin using the bot.",
@@ -92,6 +93,6 @@
   "help.header": "*Довідка Ghost Stories Bot*",
   "help.general": "*Загальні команди:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*Преміум-команди:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Адмін-команди:*\n`/setpremium <ID або @username> [днів]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID або @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID або @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID або @username>` - {{cmdBlock}}\n`/unblock <ID або @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*Адмін-команди:*\n`/setpremium <ID або @username> [днів]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID або @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID або @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID або @username>` - {{cmdBlock}}\n`/unblock <ID або @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "Вибачте, сталася непередбачена помилка. Спробуйте пізніше."
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -23,6 +23,7 @@
   "cmd.block": "封锁用户",
   "cmd.unblock": "解除封锁",
   "cmd.blocklist": "列出已封用户",
+  "cmd.status": "显示机器人状态",
   "cmd.restart": "重启机器人",
   "msg.startFirst": "请先输入 /start。",
   "msg.botStart": "👋 请输入 /start 开始使用。",
@@ -92,6 +93,6 @@
   "help.header": "*幽灵故事机器人帮助*",
   "help.general": "*常用命令：*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
   "help.premium": "*高级命令：*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*管理员命令：*\n`/setpremium <ID 或 @username> [天]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 或 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 或 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 或 @username>` - {{cmdBlock}}\n`/unblock <ID 或 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/restart` - {{cmdRestart}}",
+  "help.admin": "*管理员命令：*\n`/setpremium <ID 或 @username> [天]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 或 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 或 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 或 @username>` - {{cmdBlock}}\n`/unblock <ID 或 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
   "error.unexpected": "抱歉，发生意外错误。请稍后再试。"
 }

--- a/src/services/admin-stats.ts
+++ b/src/services/admin-stats.ts
@@ -69,16 +69,21 @@ function formatUptime(): string {
   return `${h}h ${m}m`;
 }
 
-export async function sendStartupStatus(bot: Telegraf<any>) {
-  startTimestamp = Math.floor(Date.now() / 1000);
-  const prev = readSavedStatusId();
+export function getStatusText(): string {
   const stats = getDailyStats();
-  const text =
+  return (
     `🕒 Uptime: ${formatUptime()}\n` +
     `New users: ${stats.newUsers}\n` +
     `Payments: ${stats.paidInvoices}\n` +
     `Invites redeemed: ${stats.invitesRedeemed}\n` +
-    `Errors last 24h: ${stats.errors}`;
+    `Errors last 24h: ${stats.errors}`
+  );
+}
+
+export async function sendStartupStatus(bot: Telegraf<any>) {
+  startTimestamp = Math.floor(Date.now() / 1000);
+  const prev = readSavedStatusId();
+  const text = getStatusText();
   const msg = await bot.telegram.sendMessage(BOT_ADMIN_ID, text);
   if (bot.botInfo?.id) {
     unblockUser(String(bot.botInfo.id));
@@ -100,13 +105,7 @@ export async function updateAdminStatus(bot: Telegraf<any>) {
     statusMessageId = readSavedStatusId();
   }
   if (!statusMessageId) return;
-  const stats = getDailyStats();
-  const text =
-    `🕒 Uptime: ${formatUptime()}\n` +
-    `New users: ${stats.newUsers}\n` +
-    `Payments: ${stats.paidInvoices}\n` +
-    `Invites redeemed: ${stats.invitesRedeemed}\n` +
-    `Errors last 24h: ${stats.errors}`;
+  const text = getStatusText();
   try {
     await bot.telegram.editMessageText(
       BOT_ADMIN_ID,


### PR DESCRIPTION
## Summary
- add helper to build admin status text
- implement `/status` admin command
- remove automatic pinned status message on startup
- update translations for the new command

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684758eb38cc8326adc854b1ffd185f3