### PR TITLE
Add bug reporting command

### DIFF
--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -123,3 +123,14 @@ export const countPaymentsSinceFx = createEffect((since: number) =>
 export const countReferralsSinceFx = createEffect((since: number) =>
   db.countReferralsSince(since),
 );
+
+export const addBugReportFx = createEffect(
+  (params: { telegram_id: string; username?: string; description: string }) =>
+    db.addBugReport(params.telegram_id, params.description, params.username),
+);
+
+export const listBugReportsFx = createEffect(() => db.listBugReports());
+
+export const getLastBugReportTimeFx = createEffect((telegram_id: string) =>
+  db.getLastBugReportTime(telegram_id),
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,9 @@ import {
   getProfileRequestCooldownRemainingFx,
   getLastVerifyAttemptFx,
   updateVerifyAttemptFx,
+  addBugReportFx,
+  listBugReportsFx,
+  getLastBugReportTimeFx,
 } from './db/effects';
 
 export const bot = new Telegraf<IContextBot>(BOT_TOKEN!);
@@ -100,6 +103,7 @@ function getBaseCommands(locale: string) {
     { command: 'queue', description: t(locale, 'cmd.queue') },
     { command: 'invite', description: t(locale, 'cmd.invite') },
     { command: 'profile', description: t(locale, 'cmd.profile') },
+    { command: 'bugs', description: t(locale, 'cmd.bugs') },
   ];
 }
 
@@ -123,6 +127,7 @@ function getAdminCommands(locale: string) {
     { command: 'blocklist', description: t(locale, 'cmd.blocklist') },
     { command: 'status', description: t(locale, 'cmd.status') },
     { command: 'restart', description: t(locale, 'cmd.restart') },
+    { command: 'bugs', description: t(locale, 'cmd.bugs') },
   ];
 }
 
@@ -712,6 +717,59 @@ bot.command('history', async (ctx) => {
     await ctx.reply(msg);
   } catch (e) {
     console.error('Error in /history:', e);
+    await ctx.reply(t(locale, 'error.generic'));
+  }
+});
+
+bot.command('bugs', async (ctx) => {
+  const locale = ctx.from.language_code || 'en';
+  const userId = String(ctx.from.id);
+  const isAdmin = ctx.from.id === BOT_ADMIN_ID;
+  if (!isActivated(ctx.from.id)) return ctx.reply(t(locale, 'msg.startFirst'));
+  const args = ctx.message.text.split(' ').slice(1);
+
+  if (isAdmin && args.length === 0) {
+    try {
+      const rows = await listBugReportsFx();
+      if (!rows.length) return ctx.reply(t(locale, 'bugs.none'));
+      let msg = t(locale, 'bugs.listHeader') + '\n';
+      rows.forEach((b: any, i: number) => {
+        const date = new Date(b.created_at * 1000).toLocaleDateString();
+        const user = b.username ? `@${b.username}` : b.telegram_id;
+        msg += `${i + 1}. ${user} - ${b.description} (${date})\n`;
+      });
+      return ctx.reply(msg);
+    } catch (e) {
+      console.error('Error in /bugs list:', e);
+      return ctx.reply(t(locale, 'error.generic'));
+    }
+  }
+
+  if (!args.length) {
+    return ctx.reply(t(locale, 'bug.usage'));
+  }
+
+  try {
+    const last = await getLastBugReportTimeFx(userId);
+    const now = Math.floor(Date.now() / 1000);
+    if (last && now - last < 86400) {
+      const remaining = 86400 - (now - last);
+      const h = Math.floor(remaining / 3600);
+      const m = Math.floor((remaining % 3600) / 60);
+      return sendTemporaryMessage(
+        bot,
+        ctx.chat!.id,
+        t(locale, 'bug.cooldown', { h, m }),
+      );
+    }
+    await addBugReportFx({
+      telegram_id: userId,
+      username: ctx.from.username,
+      description: args.join(' '),
+    });
+    await ctx.reply(t(locale, 'bug.reported'));
+  } catch (e) {
+    console.error('Error in /bugs:', e);
     await ctx.reply(t(locale, 'error.generic'));
   }
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,6 +12,7 @@
   "cmd.queue": "Show your queue status",
   "cmd.invite": "Show your referral link",
   "cmd.profile": "Get profile media for a user",
+  "cmd.bugs": "Report a bug",
   "cmd.monitor": "Monitor a profile for new stories",
   "cmd.unmonitor": "Stop monitoring a profile",
   "cmd.setpremium": "Mark user as premium",
@@ -91,8 +92,13 @@
   "referral.fiveUsers": "🎉 You referred 5 users! Premium extended by 7 days.",
   "referral.paid": "🎉 Your referral made a payment! Premium extended by 30 days.",
   "help.header": "*Ghost Stories Bot Help*",
-  "help.general": "*General Commands:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}",
+  "help.general": "*General Commands:*\n`/start` - {{cmdStart}}\n`/help` - {{cmdHelp}}\n`/premium` - {{cmdPremium}}\n`/freetrial` - {{cmdFreetrial}}\n`/queue` - {{cmdQueue}}\n`/invite` - {{cmdInvite}}\n`/profile` - {{cmdProfile}}\n`/verify <txid>` - {{cmdVerify}}\\n`/bugs <description>` - {{cmdBugs}}",
   "help.premium": "*Premium Commands:*\n`/monitor` - {{cmdMonitor}}\n`/unmonitor` - {{cmdUnmonitor}}",
-  "help.admin": "*Admin Commands:*\n`/setpremium <ID or @username> [days]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID or @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID or @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID or @username>` - {{cmdBlock}}\n`/unblock <ID or @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}",
-  "error.unexpected": "Sorry, an unexpected error occurred. Please try again later."
+  "help.admin": "*Admin Commands:*\n`/setpremium <ID or @username> [days]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID or @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID or @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID or @username>` - {{cmdBlock}}\n`/unblock <ID or @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\\n`/bugs` - {{cmdBugs}}",
+  "error.unexpected": "Sorry, an unexpected error occurred. Please try again later.",
+  "bug.usage": "Usage: /bugs <description>",
+  "bug.reported": "🐞 Bug reported, thanks!",
+  "bug.cooldown": "⏳ You can report another bug in {{h}}h {{m}}m.",
+  "bugs.none": "No bug reports.",
+  "bugs.listHeader": "🐞 Bug reports:"
 }


### PR DESCRIPTION
## Summary
- add bug reports table and utils
- expose bug effects
- implement `/bugs` command for reporting/viewing bugs
- document new command in English locale

## Testing
- `yarn lint` *(fails: ESLint config missing)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684760712754832697d7a7e6cadbc215