### PR TITLE
Fix invalid link preview

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -917,7 +917,7 @@ bot.on('text', async (ctx) => {
     return;
   }
 
-  await ctx.reply(t(locale, 'msg.invalidInput'));
+  await ctx.reply(t(locale, 'msg.invalidInput'), extraOptions);
 });
 
 


### PR DESCRIPTION
## Summary
- avoid showing link previews for invalid input

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684782b45adc8326b24dde72f5df0d41