### PR TITLE
Fix /bugs description on help menu

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -281,6 +281,7 @@ bot.command('help', async (ctx) => {
     cmdInvite: t(locale, 'cmd.invite'),
     cmdProfile: t(locale, 'cmd.profile'),
     cmdVerify: t(locale, 'cmd.verify'),
+    cmdBugs: t(locale, 'cmd.bugs'),
   });
 
   const isAdmin = ctx.from.id === BOT_ADMIN_ID;


### PR DESCRIPTION
## Summary
- ensure the placeholder for the `/bugs` command is replaced in the help text

## Testing
- `yarn install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684790dd1f80832680e1171d0960df5e