### PR TITLE
Fix translations for bug messages

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -96,5 +96,10 @@
   "help.admin": "*أوامر المشرف:*\n`/setpremium <ID أو @username> [أيام]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID أو @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID أو @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID أو @username>` - {{cmdBlock}}\n`/unblock <ID أو @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "عذرًا، حدث خطأ غير متوقع. يرجى المحاولة لاحقًا.",
   "cmd.bugs": "الإبلاغ عن خطأ",
-  "cmd.listbugs": "عرض تقارير الأخطاء"
+  "cmd.listbugs": "عرض تقارير الأخطاء",
+  "bug.usage": "الاستخدام: /bugs <الوصف>",
+  "bug.reported": "🐞 تم الإبلاغ عن الخطأ، شكرًا!",
+  "bug.cooldown": "⏳ يمكنك الإبلاغ عن خطأ آخر خلال {{h}}س {{m}}د.",
+  "bugs.none": "لا توجد تقارير أخطاء.",
+  "bugs.listHeader": "🐞 تقارير الأخطاء:"
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -96,5 +96,10 @@
   "help.admin": "*Admin-Befehle:*\n`/setpremium <ID oder @username> [Tage]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID oder @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID oder @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID oder @username>` - {{cmdBlock}}\n`/unblock <ID oder @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Entschuldigung, ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut.",
   "cmd.bugs": "Fehler melden",
-  "cmd.listbugs": "Fehlerberichte anzeigen"
+  "cmd.listbugs": "Fehlerberichte anzeigen",
+  "bug.usage": "Verwendung: /bugs <beschreibung>",
+  "bug.reported": "🐞 Fehler gemeldet, danke!",
+  "bug.cooldown": "⏳ Du kannst in {{h}}h {{m}}m einen weiteren Bug melden.",
+  "bugs.none": "Keine Fehlerberichte.",
+  "bugs.listHeader": "🐞 Fehlerberichte:"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -96,5 +96,10 @@
   "help.admin": "*Comandos de administrador:*\n`/setpremium <ID o @usuario> [días]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @usuario>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @usuario>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @usuario>` - {{cmdBlock}}\n`/unblock <ID o @usuario>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Lo sentimos, ocurrió un error inesperado. Por favor, inténtalo de nuevo más tarde.",
   "cmd.bugs": "Reportar un error",
-  "cmd.listbugs": "Ver informes de errores"
+  "cmd.listbugs": "Ver informes de errores",
+  "bug.usage": "Uso: /bugs <descripción>",
+  "bug.reported": "🐞 Error reportado, ¡gracias!",
+  "bug.cooldown": "⏳ Puedes reportar otro bug en {{h}}h {{m}}m.",
+  "bugs.none": "No hay reportes de bugs.",
+  "bugs.listHeader": "🐞 Reportes de bugs:"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -96,5 +96,10 @@
   "help.admin": "*Commandes admin:*\n`/setpremium <ID ou @username> [jours]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Désolé, une erreur inattendue est survenue. Veuillez réessayer plus tard.",
   "cmd.bugs": "Signaler un bug",
-  "cmd.listbugs": "Voir les rapports de bugs"
+  "cmd.listbugs": "Voir les rapports de bugs",
+  "bug.usage": "Utilisation : /bugs <description>",
+  "bug.reported": "🐞 Bug signalé, merci !",
+  "bug.cooldown": "⏳ Vous pourrez signaler un autre bug dans {{h}}h {{m}}m.",
+  "bugs.none": "Aucun rapport de bug.",
+  "bugs.listHeader": "🐞 Rapports de bugs:"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -96,5 +96,10 @@
   "help.admin": "*Comandi admin:*\n`/setpremium <ID o @username> [giorni]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID o @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID o @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID o @username>` - {{cmdBlock}}\n`/unblock <ID o @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Spiacenti, si è verificato un errore imprevisto. Riprova più tardi.",
   "cmd.bugs": "Segnala un bug",
-  "cmd.listbugs": "Visualizza segnalazioni bug"
+  "cmd.listbugs": "Visualizza segnalazioni bug",
+  "bug.usage": "Uso: /bugs <descrizione>",
+  "bug.reported": "🐞 Bug segnalato, grazie!",
+  "bug.cooldown": "⏳ Puoi segnalare un altro bug tra {{h}}h {{m}}m.",
+  "bugs.none": "Nessun report di bug.",
+  "bugs.listHeader": "🐞 Report dei bug:"
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -96,5 +96,10 @@
   "help.admin": "*관리자 명령:*\n`/setpremium <ID 또는 @username> [일]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 또는 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 또는 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 또는 @username>` - {{cmdBlock}}\n`/unblock <ID 또는 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "죄송합니다. 예상치 못한 오류가 발생했습니다. 나중에 다시 시도해주세요.",
   "cmd.bugs": "버그 신고",
-  "cmd.listbugs": "버그 리포트 보기"
+  "cmd.listbugs": "버그 리포트 보기",
+  "bug.usage": "사용법: /bugs <설명>",
+  "bug.reported": "🐞 버그가 보고되었습니다. 감사합니다!",
+  "bug.cooldown": "⏳ {{h}}시간 {{m}}분 후에 다른 버그를 신고할 수 있습니다.",
+  "bugs.none": "버그 보고가 없습니다.",
+  "bugs.listHeader": "🐞 버그 보고:"
 }

--- a/src/locales/ms.json
+++ b/src/locales/ms.json
@@ -96,5 +96,10 @@
   "help.admin": "*Arahan pentadbir:*\n`/setpremium <ID atau @username> [hari]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID atau @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID atau @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID atau @username>` - {{cmdBlock}}\n`/unblock <ID atau @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Maaf, ralat tidak dijangka berlaku. Sila cuba lagi nanti.",
   "cmd.bugs": "Laporkan pepijat",
-  "cmd.listbugs": "Lihat laporan pepijat"
+  "cmd.listbugs": "Lihat laporan pepijat",
+  "bug.usage": "Penggunaan: /bugs <deskripsi>",
+  "bug.reported": "🐞 Pepijat dilaporkan, terima kasih!",
+  "bug.cooldown": "⏳ Anda boleh melaporkan pepijat lagi dalam {{h}}h {{m}}m.",
+  "bugs.none": "Tiada laporan pepijat.",
+  "bugs.listHeader": "🐞 Laporan pepijat:"
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -96,5 +96,10 @@
   "help.admin": "*Beheercommando's:*\n`/setpremium <ID of @username> [dagen]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID of @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID of @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID of @username>` - {{cmdBlock}}\n`/unblock <ID of @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Er is een onverwachte fout opgetreden. Probeer het later opnieuw.",
   "cmd.bugs": "Bug melden",
-  "cmd.listbugs": "Bugrapporten bekijken"
+  "cmd.listbugs": "Bugrapporten bekijken",
+  "bug.usage": "Gebruik: /bugs <beschrijving>",
+  "bug.reported": "🐞 Bug gemeld, bedankt!",
+  "bug.cooldown": "⏳ Je kunt over {{h}}u {{m}}m nog een bug melden.",
+  "bugs.none": "Geen bugrapporten.",
+  "bugs.listHeader": "🐞 Bugrapporten:"
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -96,5 +96,10 @@
   "help.admin": "*Comandos de admin:*\n`/setpremium <ID ou @username> [dias]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID ou @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID ou @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID ou @username>` - {{cmdBlock}}\n`/unblock <ID ou @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Desculpe, ocorreu um erro inesperado. Tente novamente mais tarde.",
   "cmd.bugs": "Reportar um bug",
-  "cmd.listbugs": "Ver relatórios de bugs"
+  "cmd.listbugs": "Ver relatórios de bugs",
+  "bug.usage": "Uso: /bugs <descrição>",
+  "bug.reported": "🐞 Bug reportado, obrigado!",
+  "bug.cooldown": "⏳ Você poderá reportar outro bug em {{h}}h {{m}}m.",
+  "bugs.none": "Nenhum relatório de bug.",
+  "bugs.listHeader": "🐞 Relatórios de bugs:"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -96,5 +96,10 @@
   "help.admin": "*Команды администратора:*\n`/setpremium <ID или @username> [дней]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID или @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID или @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID или @username>` - {{cmdBlock}}\n`/unblock <ID или @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Извините, произошла непредвиденная ошибка. Пожалуйста, попробуйте позже.",
   "cmd.bugs": "Сообщить об ошибке",
-  "cmd.listbugs": "Просмотреть отчеты об ошибках"
+  "cmd.listbugs": "Просмотреть отчеты об ошибках",
+  "bug.usage": "Использование: /bugs <описание>",
+  "bug.reported": "🐞 Ошибка сообщена, спасибо!",
+  "bug.cooldown": "⏳ Вы сможете сообщить об ошибке через {{h}}ч {{m}}м.",
+  "bugs.none": "Нет отчетов об ошибках.",
+  "bugs.listHeader": "🐞 Отчеты об ошибках:"
 }

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -96,5 +96,10 @@
   "help.admin": "*Адмін-команди:*\n`/setpremium <ID або @username> [днів]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID або @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID або @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID або @username>` - {{cmdBlock}}\n`/unblock <ID або @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "Вибачте, сталася непередбачена помилка. Спробуйте пізніше.",
   "cmd.bugs": "Повідомити про помилку",
-  "cmd.listbugs": "Переглянути звіти про помилки"
+  "cmd.listbugs": "Переглянути звіти про помилки",
+  "bug.usage": "Використання: /bugs <опис>",
+  "bug.reported": "🐞 Помилку повідомлено, дякуємо!",
+  "bug.cooldown": "⏳ Ви зможете повідомити про іншу помилку через {{h}}г {{m}}хв.",
+  "bugs.none": "Немає звітів про помилки.",
+  "bugs.listHeader": "🐞 Звіти про помилки:"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -96,5 +96,10 @@
   "help.admin": "*管理员命令：*\n`/setpremium <ID 或 @username> [天]` - {{cmdSetpremium}} (0 = {{neverExpires}})\n`/unsetpremium <ID 或 @username>` - {{cmdUnsetpremium}}\n`/ispremium <ID 或 @username>` - {{cmdIspremium}}\n`/listpremium` - {{cmdListpremium}}\n`/users` - {{cmdUsers}}\n`/history` - {{cmdHistory}}\n`/block <ID 或 @username>` - {{cmdBlock}}\n`/unblock <ID 或 @username>` - {{cmdUnblock}}\n`/blocklist` - {{cmdBlocklist}}\n`/status` - {{cmdStatus}}\n`/restart` - {{cmdRestart}}\n`/bugreport` - {{cmdListbugs}}",
   "error.unexpected": "抱歉，发生意外错误。请稍后再试。",
   "cmd.bugs": "报告错误",
-  "cmd.listbugs": "查看错误报告"
+  "cmd.listbugs": "查看错误报告",
+  "bug.usage": "用法：/bugs <描述>",
+  "bug.reported": "🐞 Bug 已报告，谢谢！",
+  "bug.cooldown": "⏳ {{h}}小时{{m}}分钟后可再次报告。",
+  "bugs.none": "暂无错误报告。",
+  "bugs.listHeader": "🐞 错误报告："
 }


### PR DESCRIPTION
## Summary
- add bug report translations across all locales

## Testing
- `yarn install`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6847930c86e08326ab1677f04bad3403