### PR TITLE
Add SQLite maintenance routine

### DIFF
--- a/__tests__/queue-manager.test.ts
+++ b/__tests__/queue-manager.test.ts
@@ -21,6 +21,7 @@ const countRecentUserRequestsFx: any = jest.fn();
 const countPendingJobsFx: any = jest.fn();
 const recordUserRequestFx: any = jest.fn();
 const getNextQueueItemFx: any = jest.fn();
+const runMaintenanceFx: any = jest.fn();
 
 jest.mock('db/effects', () => ({
   enqueueDownloadFx,
@@ -31,6 +32,7 @@ jest.mock('db/effects', () => ({
   countPendingJobsFx,
   recordUserRequestFx,
   getNextQueueItemFx,
+  runMaintenanceFx,
 }));
 
 const bot = { telegram: { sendMessage: jest.fn() } } as any;

--- a/__tests__/queue-timeout.test.ts
+++ b/__tests__/queue-timeout.test.ts
@@ -9,6 +9,7 @@ const markProcessingFx = jest.fn();
 const markErrorFx = jest.fn();
 const markDoneFx = jest.fn();
 const cleanupQueueFx = jest.fn();
+const runMaintenanceFx = jest.fn();
 const getNextQueueItemFx: any = jest.fn();
 
 jest.mock('db/effects', () => ({
@@ -17,6 +18,7 @@ jest.mock('db/effects', () => ({
   markDoneFx,
   markErrorFx,
   cleanupQueueFx,
+  runMaintenanceFx,
 }));
 
 const getAllStoriesFx = jest.fn();

--- a/src/db/effects.ts
+++ b/src/db/effects.ts
@@ -40,6 +40,7 @@ export const markErrorFx = createEffect(
 );
 
 export const cleanupQueueFx = createEffect(() => db.cleanupQueue());
+export const runMaintenanceFx = createEffect(() => db.runMaintenance());
 
 export const wasRecentlyDownloadedFx = createEffect(
   async (params: { telegram_id: string; target_username: string; hours: number }): Promise<boolean> => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -309,6 +309,20 @@ export function cleanupQueue(): void {
   `).run();
 }
 
+let lastMaintenance = 0;
+export function runMaintenance(): void {
+  const now = Math.floor(Date.now() / 1000);
+  if (now - lastMaintenance < 86400) return;
+  lastMaintenance = now;
+  try {
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE);');
+    db.exec('VACUUM;');
+    db.exec('PRAGMA optimize;');
+  } catch (err) {
+    console.error('[DB] Maintenance error:', err);
+  }
+}
+
 // Retrieve recent usage history limited to the last 30 days
 export function getRecentHistory(limit: number): any[] {
   return db

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -7,6 +7,7 @@ import {
   markDoneFx,
   markErrorFx,
   cleanupQueueFx,
+  runMaintenanceFx,
   wasRecentlyDownloadedFx,
   getDownloadCooldownRemainingFx,
   isDuplicatePendingFx,
@@ -200,9 +201,11 @@ export async function processQueue() {
     if (!timedOut) {
       isProcessing = false;
       await cleanupQueueFx();
+      await runMaintenanceFx();
       setImmediate(processQueue);
     } else {
       await cleanupQueueFx();
+      await runMaintenanceFx();
     }
   }
 }


### PR DESCRIPTION
## Summary
- keep the database in shape with `runMaintenance`
- expose a new `runMaintenanceFx` effect
- invoke maintenance when cleaning up queue jobs
- update tests

## Testing
- `yarn lint` *(fails: ESLint config missing)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6847add36b8c832699ee019ac3be3a4e