### PR TITLE
Fix: disable link previews in history listing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -733,7 +733,7 @@ bot.command('history', async (ctx) => {
       const type = r.is_bot ? t(locale, 'label.bot') : t(locale, 'label.user');
       msg += `${i + 1}. ${user} [${type}] -> ${r.target_username} [${r.status}] ${date}\n`;
     });
-    await ctx.reply(msg);
+    await ctx.reply(msg, { link_preview_options: { is_disabled: true } });
   } catch (e) {
     console.error('Error in /history:', e);
     await ctx.reply(t(locale, 'error.generic'));


### PR DESCRIPTION
## Summary
- stop Telegram link previews from showing when listing history

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6847da3b56d48326b5d3127793857236