### PR TITLE
Fix missing admin status description

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -310,6 +310,7 @@ bot.command('help', async (ctx) => {
         cmdBlock: t(locale, 'cmd.block'),
         cmdUnblock: t(locale, 'cmd.unblock'),
         cmdBlocklist: t(locale, 'cmd.blocklist'),
+        cmdStatus: t(locale, 'cmd.status'),
         cmdRestart: t(locale, 'cmd.restart'),
         cmdListbugs: t(locale, 'cmd.listbugs'),
         neverExpires: t(locale, 'premium.neverExpires'),


### PR DESCRIPTION
## Summary
- include `cmdStatus` when translating admin help text

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485b2ce61c8326b1ab3683129157a1