### PR TITLE
Fix locale detection

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -29,7 +29,8 @@ const locales: Record<string, Record<string, string>> = {
 };
 
 export function t(locale: string | undefined, key: string, vars: Record<string, string | number> = {}): string {
-  const lang = locale && locales[locale] ? locale : 'en';
+  const normalized = (locale || '').toLowerCase().split(/[_-]/)[0];
+  const lang = normalized && locales[normalized] ? normalized : 'en';
   const fallback = locales['en'][key] || key;
   let text = locales[lang][key] || fallback;
   for (const [k, v] of Object.entries(vars)) {


### PR DESCRIPTION
## Summary
- handle regional variants by normalizing locale codes before lookup

## Testing
- `npm test` *(fails: jest not found)*
- `yarn install` *(fails: peer dependencies conflict)*
- `yarn test` *(fails: couldn't find node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6848861eb0c48326b3a93126542e8404