### PR TITLE
Fix node 22 startup and run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ FROM node:22-alpine
 COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 # Install only the remaining system dependencies.
-RUN apk add --no-cache sqlite sqlite-dev python3 make g++
+RUN apk add --no-cache sqlite sqlite-dev python3 make g++ shadow
 
 #RUN apk add --no-cache sqlite sqlite-dev python3 make g++
 
@@ -57,6 +57,8 @@ ENV NODE_ENV=production
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN chown -R appuser:appgroup /app
+USER appuser
 
 # Set our script as the entrypoint for the container.
 ENTRYPOINT ["entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,16 +12,17 @@ PGID=${PGID:-568}
 
 echo "Starting with UID: $PUID, GID: $PGID"
 
-# Change the group ID of 'appgroup' to match the host's group ID
-groupmod -o -g "$PGID" appgroup
-# Change the user ID of 'appuser' to match the host's user ID
-usermod -o -u "$PUID" appuser
-
+# Change IDs only if running as root and required tools exist
+if [ "$(id -u)" = "0" ]; then
+  command -v groupmod >/dev/null 2>&1 && groupmod -o -g "$PGID" appgroup || true
+  command -v usermod >/dev/null 2>&1 && usermod -o -u "$PUID" appuser || true
+fi
 # =========================================================================
 # PERMISSIONS
 # =========================================================================
-chown -R appuser:appgroup /app/data
-
+if [ "$(id -u)" = "0" ]; then
+  chown -R appuser:appgroup /app/data
+fi
 # =========================================================================
 # EXECUTE MAIN COMMAND
 # =========================================================================


### PR DESCRIPTION
## Summary
- fix entrypoint to work without `groupmod`/`usermod` when running as non-root
- install `shadow` tools and default to `appuser`

## Testing
- `yarn install`
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6848cda98c1483268891ae314ebdde28