### PR TITLE
Fix container startup by removing USER directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ ENV NODE_ENV=production
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 RUN chown -R appuser:appgroup /app
-USER appuser
 
 # Set our script as the entrypoint for the container.
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
## Summary
- remove `USER appuser` from Dockerfile so that the entrypoint can start as root and gosu can drop to appuser

## Testing
- `yarn install`
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6848d0ba5b788326a4eee407cf83fbbf