### PR TITLE
Ensure Docker uses non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 RUN chown -R appuser:appgroup /app
 
+# Run the container as the non-root user by default
+USER appuser
+
 # Set our script as the entrypoint for the container.
 ENTRYPOINT ["entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,5 +28,9 @@ fi
 # =========================================================================
 # `exec gosu appuser "$@"` switches from the root user to 'appuser'
 # and then executes the command provided in the Dockerfile's CMD.
-echo "Dropping root privileges and starting application..."
-exec gosu appuser "$@"
+if [ "$(id -u)" = "0" ]; then
+  echo "Dropping root privileges and starting application..."
+  exec gosu appuser "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
## Summary
- run the container as `appuser`
- run `gosu` only if started as root

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6848d3d73e8c8326b5e385d457254a92