### PR TITLE
Implement interactive login prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,14 @@ bot.telegram.sendMediaGroup(
 docker compose up -d
 ```
 
-The first start will fail with <code>USERBOT_PHONE_CODE is required for first login!</code>.
-Telegram will send a login code to the phone number specified in <code>USERBOT_PHONE_NUMBER</code>.
-Add this code to your <code>.env</code> as <code>USERBOT_PHONE_CODE</code> and run the command again.
-Once authentication completes the session file is saved, so you can remove the
-<code>USERBOT_PHONE_CODE</code> line from the environment file.
+The first start will fail with <code>USERBOT_PHONE_CODE is required for first login!</code>
+unless the code is provided. Telegram sends the login code to the phone number
+specified in <code>USERBOT_PHONE_NUMBER</code>.
+You can either add this code to your <code>.env</code> as <code>USERBOT_PHONE_CODE</code>
+and rerun the command, or simply start the container and enter the code when
+prompted interactively. Once authentication completes the session file is saved,
+so you can remove the <code>USERBOT_PHONE_CODE</code> line from the environment
+file.
 
 ### Viewing Logs
 

--- a/src/config/userbot.ts
+++ b/src/config/userbot.ts
@@ -1,5 +1,6 @@
 import { TelegramClient } from 'telegram';
 import { StoreSession } from 'telegram/sessions';
+import readline from 'readline';
 
 import {
   USERBOT_API_HASH,
@@ -68,15 +69,28 @@ async function initClient() {
   );
 
   const password = USERBOT_PASSWORD || '';
-  const phoneCode = USERBOT_PHONE_CODE || '';
+  let phoneCode = USERBOT_PHONE_CODE || '';
+
+  const promptInput = async (query: string): Promise<string> => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) =>
+      rl.question(query, (answer) => {
+        rl.close();
+        resolve(answer.trim());
+      }),
+    );
+  };
 
   await client.start({
     phoneNumber: USERBOT_PHONE_NUMBER,
     password: async () => {
-      if (!password) throw new Error('USERBOT_PASSWORD is required for this account!');
-      return password;
+      if (password) return password;
+      return promptInput('Please enter two-factor authentication password: ');
     },
     phoneCode: async (_isCodeViaApp?: boolean) => {
+      if (!phoneCode) {
+        phoneCode = await promptInput('Please enter the Telegram login code: ');
+      }
       if (!phoneCode) throw new Error('USERBOT_PHONE_CODE is required for first login!');
       return phoneCode;
     },


### PR DESCRIPTION
## Summary
- prompt for phone code and password at runtime if missing
- update README with interactive phone code instructions

## Testing
- `yarn install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d74181c483268f3635af2a882a65