### PR TITLE
Add session file cleanup routine

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import {
 } from './services/btc-payment';
 import { getStatusText } from './services/admin-stats';
 import { scheduleDatabaseBackups } from './services/backup-service';
+import { scheduleSessionCleanup } from './services/session-cleanup-service';
 import { handleUpgrade } from 'controllers/upgrade';
 import { handlePremium } from 'controllers/premium';
 import { sendProfileMedia } from 'controllers/send-profile-media';
@@ -969,6 +970,7 @@ async function startApp() {
   startMonitorLoop();
   resumePendingChecks();
   scheduleDatabaseBackups();
+  scheduleSessionCleanup();
   await bot.telegram.setMyCommands(getBaseCommands('en'));
   await bot.telegram.setMyCommands(
     [...getBaseCommands('en'), ...getPremiumCommands('en'), ...getAdminCommands('en')],

--- a/src/services/session-cleanup-service.ts
+++ b/src/services/session-cleanup-service.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import cron from 'node-cron';
+import { DB_PATH } from '../db';
+
+const DATA_DIR = path.dirname(DB_PATH);
+const SESSION_PREFIX = 'userbot-session';
+const KEEP_DAYS = 7;
+
+function cleanupOldSessions(): void {
+  const cutoff = Date.now() - KEEP_DAYS * 24 * 60 * 60 * 1000;
+  const files = fs.readdirSync(DATA_DIR).filter((f) => f.startsWith(SESSION_PREFIX));
+  for (const name of files) {
+    try {
+      const file = path.join(DATA_DIR, name);
+      const mtime = fs.statSync(file).mtime.getTime();
+      if (mtime < cutoff) {
+        fs.unlinkSync(file);
+      }
+    } catch (err) {
+      console.error('[SessionCleanup] Failed to remove file', name, err);
+    }
+  }
+}
+
+export function scheduleSessionCleanup(): void {
+  cleanupOldSessions();
+  cron.schedule('30 3 * * *', () => {
+    try {
+      cleanupOldSessions();
+    } catch (err) {
+      console.error('[SessionCleanup] Error during cleanup', err);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- schedule a daily cleanup job for old `userbot-session*` files
- wire the cleanup in the app startup

## Testing
- `yarn install`
- `npx --yes jest`

------
https://chatgpt.com/codex/tasks/task_e_6848e04c2d4c83269a888b0929966816