### PR TITLE
Fix admin pinned story pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Logs are available with `docker logs ghost-stories-bot` and additionally stored 
 ## Usage
 
 Send the bot a username, phone number or link to a story. The bot will fetch the available stories and return them to you. Premium users can monitor up to five profiles with `/monitor <@username|+15555555555>` and `/unmonitor <@username>`.
+Administrators browse stories with the same paginated interface to prevent large downloads from clogging the queue.
 
 After paying for Premium you can verify the transaction manually with:
 

--- a/src/controllers/send-pinned-stories.ts
+++ b/src/controllers/send-pinned-stories.ts
@@ -36,12 +36,12 @@ export async function sendPinnedStories({ stories, task }: SendStoriesArgs): Pro
     const STORY_LIMIT_FOR_FREE_USERS = 5;
     let wasLimited = false;
 
-    // Pagination setup for premium users (non-admin) if too many stories
+    // Pagination setup for premium users (and admin) if too many stories
     const PER_PAGE = 5;
     let hasMorePages = false;
     const nextStories: Record<string, number[]> = {};
 
-    if (task.isPremium && !isAdmin && mapped.length > PER_PAGE) {
+    if ((task.isPremium || isAdmin) && mapped.length > PER_PAGE) {
       hasMorePages = true;
       const currentStories: MappedStoryItem[] = mapped.slice(0, PER_PAGE);
       for (let i = PER_PAGE; i < mapped.length; i += PER_PAGE) {


### PR DESCRIPTION
## Summary
- admin story downloads should also use paginated batches
- document that admins use pagination

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68490a312fe883269c1601dc651aa77f