### PR TITLE
Add fallback for phone numbers using temporary contacts

### DIFF
--- a/src/controllers/get-stories.ts
+++ b/src/controllers/get-stories.ts
@@ -3,7 +3,7 @@
 import { Userbot } from 'config/userbot';
 import { createEffect } from 'effector';
 import { bot } from 'index';
-import { timeout, sendTemporaryMessage, isValidStoryLink } from 'lib';
+import { timeout, sendTemporaryMessage, isValidStoryLink, getEntityWithTempContact } from 'lib';
 import { UserInfo, NotifyAdminParams } from 'types';
 import { Api } from 'telegram';
 import { FloodWaitError } from 'telegram/errors';
@@ -23,7 +23,7 @@ export const getAllStoriesFx = createEffect(async (task: UserInfo) => {
     );
 
     const client = await Userbot.getInstance();
-    const entity = await client.getEntity(task.link);
+    const entity = await getEntityWithTempContact(task.link);
     notifyAdmin({ task, status: 'start' });
 
     // This path handles pagination clicks from inline buttons.

--- a/src/controllers/send-profile-media.ts
+++ b/src/controllers/send-profile-media.ts
@@ -1,6 +1,6 @@
 import { Userbot } from 'config/userbot';
 import { bot } from 'index';
-import { sendTemporaryMessage, chunkArray } from 'lib';
+import { sendTemporaryMessage, chunkArray, getEntityWithTempContact } from 'lib';
 import { Api } from 'telegram';
 import { notifyAdmin } from 'controllers/send-message';
 import { User } from 'telegraf/typings/core/types/typegram';
@@ -24,7 +24,7 @@ export async function sendProfileMedia(
   try {
 
     const client = await Userbot.getInstance();
-    const entity = await client.getEntity(input);
+    const entity = await getEntityWithTempContact(input);
 
     const photos: Api.Photo[] = [];
     let offset = 0;

--- a/src/lib/contacts.ts
+++ b/src/lib/contacts.ts
@@ -1,0 +1,51 @@
+import { Userbot } from 'config/userbot';
+import { Api } from 'telegram';
+import { isPhoneNumber } from './helpers';
+import bigInt, { BigInteger } from 'big-integer';
+
+export async function getEntityWithTempContact(input: string): Promise<any> {
+  const client = await Userbot.getInstance();
+  if (!isPhoneNumber(input)) {
+    return client.getEntity(input);
+  }
+
+  let importedId: BigInteger | null = null;
+  let accessHash: BigInteger | null = null;
+  try {
+    const result = await client.invoke(
+      new Api.contacts.ImportContacts({
+        contacts: [
+          new Api.InputPhoneContact({
+            clientId: bigInt(Date.now()),
+            phone: input,
+            firstName: 'Temp',
+            lastName: 'User',
+          }),
+        ],
+      })
+    );
+    if ('imported' in result && result.imported.length > 0) {
+      importedId = result.imported[0].userId;
+      const user = (result.users as any[]).find(
+        (u: any) => 'id' in u && u.id.equals(importedId)
+      );
+      if (user && 'accessHash' in user) {
+        accessHash = user.accessHash as BigInteger;
+      }
+    }
+    return await client.getEntity(input);
+  } finally {
+    if (importedId && accessHash) {
+      try {
+        await client.invoke(
+          new Api.contacts.DeleteContacts({
+            id: [new Api.InputUser({ userId: importedId, accessHash })],
+          })
+        );
+      } catch (err) {
+        console.error('[contacts] Failed to remove temporary contact:', err);
+      }
+    }
+  }
+}
+

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -134,3 +134,8 @@ export function isValidStoryLink(link: string): boolean {
     link.trim(),
   );
 }
+
+// Check if the provided string is a phone number in international format
+export function isPhoneNumber(text: string): boolean {
+  return /^\+\d{5,15}$/.test(text.trim());
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './helpers';
+export * from './contacts';


### PR DESCRIPTION
## Summary
- add `getEntityWithTempContact` helper to temporarily add a phone number as a contact
- export new helper from `lib`
- detect phone numbers with new `isPhoneNumber` util
- use the helper when retrieving stories or profile media

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684912d69fd483268db070da7040c7b4