### PR TITLE
Add admin /welcome command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ function getAdminCommands(locale: string) {
     { command: 'status', description: t(locale, 'cmd.status') },
     { command: 'restart', description: t(locale, 'cmd.restart') },
     { command: 'flush', description: t(locale, 'cmd.flush') },
+    { command: 'welcome', description: t(locale, 'cmd.welcome') },
     { command: 'bugreport', description: t(locale, 'cmd.listbugs') },
     { command: 'bugs', description: t(locale, 'cmd.bugs') },
   ];
@@ -823,6 +824,18 @@ bot.command('flush', async (ctx) => {
     console.error('Error in /flush:', e);
     await ctx.reply(t(locale, 'error.generic'));
   }
+});
+
+bot.command('welcome', async (ctx) => {
+  if (ctx.from.id != BOT_ADMIN_ID) return;
+  const locale = ctx.from.language_code || 'en';
+  await ctx.reply(t(locale, 'msg.botStart'), {
+    reply_markup: {
+      keyboard: [['/start']],
+      resize_keyboard: true,
+      one_time_keyboard: true,
+    },
+  });
 });
 
 // --- Handle button presses ---

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -29,6 +29,7 @@
   "cmd.status": "Show bot status",
   "cmd.restart": "Restart the bot",
   "cmd.flush": "Flush the download queue",
+  "cmd.welcome": "Show the initial welcome message",
   "msg.startFirst": "Please type /start first.",
   "msg.botStart": "👋 Please type /start to begin using the bot.",
   "msg.invalidInput": "🚫 Invalid input. Send `@username`, `+19875551234` or `https://t.me/username/s/1`. Type /help for more info.",


### PR DESCRIPTION
## Summary
- implement `/welcome` command for admins to preview the startup prompt
- expose `/welcome` in the admin command list
- document the command description in `en.json`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849c63bf05c8326829b92337751fb60