### PR TITLE
Improve debug log configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,5 @@ BTC_ZPUB=
 # Optional: where to store error logs
 LOG_FILE=./data/error.log
 # Optional: path to store verbose debug logs. Leave empty to disable file logging
-DEBUG_LOG_FILE=
+# Recommended: ./data/debug.log so the path has the correct permissions
+DEBUG_LOG_FILE=./data/debug.log

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project packages a Telegram bot for anonymously viewing stories. It is base
    - Optionally `USERBOT_PASSWORD` if that account has two‑factor authentication enabled
    - Leave `USERBOT_PHONE_CODE` empty on the first run
    - Fill in `BOT_ADMIN_ID` and either `BTC_WALLET_ADDRESS` or one of `BTC_XPUB`, `BTC_YPUB`, `BTC_ZPUB`
-   - Optional: `LOG_FILE` and `DEBUG_LOG_FILE` to change where runtime errors are stored
+   - Optional: `LOG_FILE` and `DEBUG_LOG_FILE` to change where runtime errors are stored. If `DEBUG_LOG_FILE` is a relative path, it is created inside the container's data directory.
 
 2. Build and start the container:
 
@@ -21,7 +21,7 @@ docker compose up
 
 The compose file sets `stdin_open: true` and `tty: true` so you can enter the SMS code in the terminal on the first run. When the container prints `USERBOT_PHONE_CODE is required for first login!`, type the code you receive from Telegram. After the session is saved to `storage_entry/userbot-session`, future starts do not require a code and you can run in detached mode with `docker compose up -d`.
 
-Logs are available with `docker logs ghost-stories-bot` and additionally stored in the file pointed to by `LOG_FILE`.
+Logs are available with `docker logs ghost-stories-bot` and additionally stored in the file pointed to by `LOG_FILE`. When `DEBUG_LOG_FILE` is set, all console output is mirrored to that path for troubleshooting.
 
 ## Usage
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -49,4 +49,14 @@ if (!BTC_WALLET_ADDRESS && !BTC_XPUB && !BTC_YPUB && !BTC_ZPUB) {
 export const LOG_FILE = process.env.LOG_FILE || parsed?.LOG_FILE || path.join(__dirname, '../../data/error.log');
 
 // debug log file path for verbose logging
-export const DEBUG_LOG_FILE = process.env.DEBUG_LOG_FILE || parsed?.DEBUG_LOG_FILE || '';
+/**
+ * Path for verbose logs. If a relative path is supplied it is resolved from the
+ * project root so it ends up alongside `LOG_FILE` in the mounted data volume.
+ */
+export const DEBUG_LOG_FILE = (() => {
+  const file = process.env.DEBUG_LOG_FILE || parsed?.DEBUG_LOG_FILE || '';
+  if (file && !path.isAbsolute(file)) {
+    return path.join(__dirname, '../../', file);
+  }
+  return file;
+})();


### PR DESCRIPTION
## Summary
- resolve relative DEBUG_LOG_FILE paths from project root so permissions match data directory
- document debug log path behaviour in README
- update example env file with recommended debug log path

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849d05fe0848326bc6070ce9e9134c3