### PR TITLE
Fix default debug log path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,6 @@ BTC_ZPUB=
 
 # Optional: where to store error logs
 LOG_FILE=./data/error.log
-# Optional: path to store verbose debug logs. Leave empty to disable file logging
-# Recommended: ./data/debug.log so the path has the correct permissions
-DEBUG_LOG_FILE=./data/debug.log
+# Optional: path to store verbose debug logs. Leave empty to use the default
+# `./data/debug.log` path (recommended so the file has correct permissions)
+DEBUG_LOG_FILE=

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project packages a Telegram bot for anonymously viewing stories. It is base
    - Optionally `USERBOT_PASSWORD` if that account has two‑factor authentication enabled
    - Leave `USERBOT_PHONE_CODE` empty on the first run
    - Fill in `BOT_ADMIN_ID` and either `BTC_WALLET_ADDRESS` or one of `BTC_XPUB`, `BTC_YPUB`, `BTC_ZPUB`
-   - Optional: `LOG_FILE` and `DEBUG_LOG_FILE` to change where runtime errors are stored. If `DEBUG_LOG_FILE` is a relative path, it is created inside the container's data directory.
+   - Optional: `LOG_FILE` and `DEBUG_LOG_FILE` to change where runtime errors are stored. `DEBUG_LOG_FILE` defaults to `./data/debug.log` and relative paths are created inside the container's data directory.
 
 2. Build and start the container:
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -54,9 +54,11 @@ export const LOG_FILE = process.env.LOG_FILE || parsed?.LOG_FILE || path.join(__
  * project root so it ends up alongside `LOG_FILE` in the mounted data volume.
  */
 export const DEBUG_LOG_FILE = (() => {
-  const file = process.env.DEBUG_LOG_FILE || parsed?.DEBUG_LOG_FILE || '';
-  if (file && !path.isAbsolute(file)) {
-    return path.join(__dirname, '../../', file);
+  let file = process.env.DEBUG_LOG_FILE || parsed?.DEBUG_LOG_FILE;
+  if (!file) {
+    file = path.join(__dirname, '../../data/debug.log');
+  } else if (!path.isAbsolute(file)) {
+    file = path.join(__dirname, '../../', file);
   }
   return file;
 })();


### PR DESCRIPTION
## Summary
- point DEBUG_LOG_FILE to `./data/debug.log` by default
- note the default path in README
- adjust `.env.example`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849d35264188326a2a9fecebde0ac21