### PR TITLE
Simplify debug log setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,5 @@ BTC_ZPUB=
 
 # Optional: where to store error logs
 LOG_FILE=./data/error.log
-# Optional: path to store verbose debug logs. Leave empty to use the default
-# `./data/debug.log` path (recommended so the file has correct permissions)
-DEBUG_LOG_FILE=
+# Optional: enable verbose logging to ./data/debug.log (set to true or 1)
+DEBUG_LOG=

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project packages a Telegram bot for anonymously viewing stories. It is base
    - Optionally `USERBOT_PASSWORD` if that account has two‑factor authentication enabled
    - Leave `USERBOT_PHONE_CODE` empty on the first run
    - Fill in `BOT_ADMIN_ID` and either `BTC_WALLET_ADDRESS` or one of `BTC_XPUB`, `BTC_YPUB`, `BTC_ZPUB`
-   - Optional: `LOG_FILE` and `DEBUG_LOG_FILE` to change where runtime errors are stored. `DEBUG_LOG_FILE` defaults to `./data/debug.log` and relative paths are created inside the container's data directory.
+  - Optional: `LOG_FILE` to change where runtime errors are stored. Set `DEBUG_LOG=true` to also mirror all console output to `./data/debug.log`.
 
 2. Build and start the container:
 
@@ -21,7 +21,7 @@ docker compose up
 
 The compose file sets `stdin_open: true` and `tty: true` so you can enter the SMS code in the terminal on the first run. When the container prints `USERBOT_PHONE_CODE is required for first login!`, type the code you receive from Telegram. After the session is saved to `storage_entry/userbot-session`, future starts do not require a code and you can run in detached mode with `docker compose up -d`.
 
-Logs are available with `docker logs ghost-stories-bot` and additionally stored in the file pointed to by `LOG_FILE`. When `DEBUG_LOG_FILE` is set, all console output is mirrored to that path for troubleshooting.
+Logs are available with `docker logs ghost-stories-bot` and additionally stored in the file pointed to by `LOG_FILE`. When `DEBUG_LOG` is enabled, all console output is mirrored to `./data/debug.log` for troubleshooting.
 
 ## Usage
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -46,19 +46,24 @@ if (!BTC_WALLET_ADDRESS && !BTC_XPUB && !BTC_YPUB && !BTC_ZPUB) {
 }
 
 // error log file path
-export const LOG_FILE = process.env.LOG_FILE || parsed?.LOG_FILE || path.join(__dirname, '../../data/error.log');
+export const LOG_FILE = process.env.LOG_FILE || parsed?.LOG_FILE || path.join(
+  __dirname,
+  '../../data/error.log',
+);
 
-// debug log file path for verbose logging
+// verbose debugging
 /**
- * Path for verbose logs. If a relative path is supplied it is resolved from the
- * project root so it ends up alongside `LOG_FILE` in the mounted data volume.
+ * When `DEBUG_LOG` is truthy all console output is mirrored to
+ * `/app/data/debug.log` (inside the container). The path is fixed so the user
+ * does not need to provide it.
  */
-export const DEBUG_LOG_FILE = (() => {
-  let file = process.env.DEBUG_LOG_FILE || parsed?.DEBUG_LOG_FILE;
-  if (!file) {
-    file = path.join(__dirname, '../../data/debug.log');
-  } else if (!path.isAbsolute(file)) {
-    file = path.join(__dirname, '../../', file);
-  }
-  return file;
+export const DEBUG_LOG = (() => {
+  const flag = process.env.DEBUG_LOG ?? parsed?.DEBUG_LOG ?? '';
+  return ['1', 'true', 'yes'].includes(String(flag).toLowerCase());
 })();
+
+// Debug log file path is always relative to the application data directory
+export const DEBUG_LOG_FILE = path.join(
+  __dirname,
+  '../../data/debug.log',
+);

--- a/src/config/setup-logs.ts
+++ b/src/config/setup-logs.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
-import { DEBUG_LOG_FILE } from './env-config';
+import { DEBUG_LOG, DEBUG_LOG_FILE } from './env-config';
 
-// Only mirror logs to a file when DEBUG_LOG_FILE is provided
-if (DEBUG_LOG_FILE) {
+// Only mirror logs to a file when DEBUG_LOG is enabled
+if (DEBUG_LOG) {
   const logFile = DEBUG_LOG_FILE;
   const logDir = path.dirname(logFile);
   if (!fs.existsSync(logDir)) {


### PR DESCRIPTION
## Summary
- allow enabling debug logging via `DEBUG_LOG` boolean
- write verbose logs to a fixed `/app/data/debug.log` path
- update environment example and README

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849d66d52308326b2a811884c2f6489