### PR TITLE
Fix userbot session path

### DIFF
--- a/src/config/userbot.ts
+++ b/src/config/userbot.ts
@@ -60,7 +60,7 @@ export class Userbot {
 
 async function initClient() {
   const dataDir = path.dirname(DB_PATH);
-  const storeSessionPath = path.join(dataDir, 'userbot-session');
+  const storeSessionPath = path.resolve(dataDir, 'userbot-session');
   const storeSession = new StoreSession(storeSessionPath);
 
   const client = new TelegramClient(

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { DownloadQueueItem, UserInfo } from 'types';
 
-export const DB_PATH = path.join(__dirname, '../../data/database.db');
+export const DB_PATH = path.resolve(__dirname, '../../data/database.db');
 const dataDir = path.dirname(DB_PATH);
 if (!fs.existsSync(dataDir)) {
   fs.mkdirSync(dataDir, { recursive: true });


### PR DESCRIPTION
## Summary
- fix DB_PATH creation using `path.resolve`
- resolve userbot session path relative to data directory

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849dc69f9b88326b9603c55e81b5cc9