### PR TITLE
Centralize data directory path

### DIFF
--- a/src/config/userbot.ts
+++ b/src/config/userbot.ts
@@ -2,7 +2,7 @@ import { TelegramClient } from 'telegram';
 import { StoreSession } from 'telegram/sessions';
 import readline from 'readline';
 import path from 'path';
-import { DB_PATH } from '../db';
+import { DATA_DIR } from '../db';
 
 import {
   USERBOT_API_HASH,
@@ -59,8 +59,8 @@ export class Userbot {
 }
 
 async function initClient() {
-  const dataDir = path.dirname(DB_PATH);
-  const storeSessionPath = path.resolve(dataDir, 'userbot-session');
+  // Store the userbot session alongside the main database and other data
+  const storeSessionPath = path.resolve(DATA_DIR, 'userbot-session');
   const storeSession = new StoreSession(storeSessionPath);
 
   const client = new TelegramClient(

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -5,8 +5,15 @@ import fs from 'fs';
 import path from 'path';
 import { DownloadQueueItem, UserInfo } from 'types';
 
-export const DB_PATH = path.resolve(__dirname, '../../data/database.db');
-const dataDir = path.dirname(DB_PATH);
+/**
+ * Base directory where all runtime data is stored.
+ * Using a single constant helps avoid path resolution issues
+ * when the application is executed from different locations.
+ */
+export const DATA_DIR = path.resolve(__dirname, '../../data');
+export const DB_PATH = path.join(DATA_DIR, 'database.db');
+// Ensure the data directory exists before using it
+const dataDir = DATA_DIR;
 if (!fs.existsSync(dataDir)) {
   fs.mkdirSync(dataDir, { recursive: true });
 }

--- a/src/services/backup-service.ts
+++ b/src/services/backup-service.ts
@@ -1,9 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import cron from 'node-cron';
-import { DB_PATH } from '../db';
+import { DB_PATH, DATA_DIR } from '../db';
 
-const BACKUP_DIR = path.join(path.dirname(DB_PATH), 'backups');
+// Place backups inside the main data directory so all runtime files
+// are grouped together under a single folder.
+const BACKUP_DIR = path.join(DATA_DIR, 'backups');
 const KEEP_DAYS = 7;
 
 function ensureDir() {

--- a/src/services/session-cleanup-service.ts
+++ b/src/services/session-cleanup-service.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import cron from 'node-cron';
-import { DB_PATH } from '../db';
+import { DATA_DIR } from '../db';
 
-const DATA_DIR = path.dirname(DB_PATH);
+// Temporary session files are stored in the same data directory as the
+// database to keep everything contained under a single folder.
 const SESSION_PREFIX = 'userbot-session';
 const KEEP_DAYS = 7;
 


### PR DESCRIPTION
## Summary
- centralize `DATA_DIR` constant in db module
- store userbot session under new DATA_DIR
- update backup and cleanup services to use DATA_DIR

## Testing
- `yarn run build`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849df0892788326b17242fea02ed3ed