### PR TITLE
Use configurable /data path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     environment:
       - PUID=568
       - PGID=568
-    # This mounts your persistent data directory on the host to the /app/data
+      - DATA_DIR=/data
+    # This mounts your persistent data directory on the host to the /data
     # directory inside the container.
     volumes:
-      - ./storage_entry:/app/data
+      - ./storage_entry:/data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ fi
 # PERMISSIONS
 # =========================================================================
 if [ "$(id -u)" = "0" ]; then
-  chown -R appuser:appgroup /app/data
+  chown -R appuser:appgroup /data
 fi
 # =========================================================================
 # EXECUTE MAIN COMMAND

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -45,16 +45,20 @@ if (!BTC_WALLET_ADDRESS && !BTC_XPUB && !BTC_YPUB && !BTC_ZPUB) {
   );
 }
 
+// Base directory for all runtime data. Defaults to a `data` folder relative to
+// the project when running locally. The Docker setup passes DATA_DIR=/data so
+// files are stored in the mounted volume.
+export const DATA_DIR =
+  process.env.DATA_DIR || path.resolve(__dirname, '../../data');
+
 // error log file path
-export const LOG_FILE = process.env.LOG_FILE || parsed?.LOG_FILE || path.join(
-  __dirname,
-  '../../data/error.log',
-);
+export const LOG_FILE =
+  process.env.LOG_FILE || parsed?.LOG_FILE || path.join(DATA_DIR, 'error.log');
 
 // verbose debugging
 /**
  * When `DEBUG_LOG` is truthy all console output is mirrored to
- * `/app/data/debug.log` (inside the container). The path is fixed so the user
+ * `/data/debug.log` (inside the container). The path is fixed so the user
  * does not need to provide it.
  */
 export const DEBUG_LOG = (() => {
@@ -63,7 +67,4 @@ export const DEBUG_LOG = (() => {
 })();
 
 // Debug log file path is always relative to the application data directory
-export const DEBUG_LOG_FILE = path.join(
-  __dirname,
-  '../../data/debug.log',
-);
+export const DEBUG_LOG_FILE = path.join(DATA_DIR, 'debug.log');

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -6,11 +6,12 @@ import path from 'path';
 import { DownloadQueueItem, UserInfo } from 'types';
 
 /**
- * Base directory where all runtime data is stored.
- * Using a single constant helps avoid path resolution issues
- * when the application is executed from different locations.
+ * Base directory where all runtime data is stored. Defaults to a `data` folder
+ * relative to the project when running locally. Set the DATA_DIR environment
+ * variable (e.g. to `/data` inside the Docker container) to override.
  */
-export const DATA_DIR = path.resolve(__dirname, '../../data');
+export const DATA_DIR =
+  process.env.DATA_DIR || path.resolve(__dirname, '../../data');
 export const DB_PATH = path.join(DATA_DIR, 'database.db');
 // Ensure the data directory exists before using it
 const dataDir = DATA_DIR;

--- a/src/services/admin-stats.ts
+++ b/src/services/admin-stats.ts
@@ -6,9 +6,10 @@ import { db, unblockUser } from '../db';
 
 let startTimestamp = Math.floor(Date.now() / 1000);
 let statusMessageId: number | null = null;
+const BASE_DIR = process.env.DATA_DIR || path.resolve(__dirname, '../../data');
 const STATUS_ID_FILE =
   process.env.STATUS_ID_FILE ||
-  path.join(__dirname, '../../data/admin_status_id');
+  path.join(BASE_DIR, 'admin_status_id');
 
 function readSavedStatusId(): number | null {
   try {


### PR DESCRIPTION
## Summary
- support changing DATA_DIR via environment variable
- default DATA_DIR to a local `data` folder if not provided
- adjust entrypoint permissions and compose volume to use `/data`
- resolve admin status file relative to DATA_DIR

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849e5028f0c83268c2c28915dbdc432