### PR TITLE
Remove DATA_DIR environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,6 @@ BTC_YPUB=
 BTC_ZPUB=
 
 # Optional: where to store error logs
-LOG_FILE=./data/error.log
-# Optional: enable verbose logging to ./data/debug.log (set to true or 1)
+LOG_FILE=/data/error.log
+# Optional: enable verbose logging to /data/debug.log (set to true or 1)
 DEBUG_LOG=

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project packages a Telegram bot for anonymously viewing stories. It is base
    - Optionally `USERBOT_PASSWORD` if that account has two‑factor authentication enabled
    - Leave `USERBOT_PHONE_CODE` empty on the first run
    - Fill in `BOT_ADMIN_ID` and either `BTC_WALLET_ADDRESS` or one of `BTC_XPUB`, `BTC_YPUB`, `BTC_ZPUB`
-  - Optional: `LOG_FILE` to change where runtime errors are stored. Set `DEBUG_LOG=true` to also mirror all console output to `./data/debug.log`.
+  - Optional: `LOG_FILE` to change where runtime errors are stored. Set `DEBUG_LOG=true` to also mirror all console output to `/data/debug.log`.
 
 2. Build and start the container:
 
@@ -19,9 +19,13 @@ This project packages a Telegram bot for anonymously viewing stories. It is base
 docker compose up
 ```
 
-The compose file sets `stdin_open: true` and `tty: true` so you can enter the SMS code in the terminal on the first run. When the container prints `USERBOT_PHONE_CODE is required for first login!`, type the code you receive from Telegram. After the session is saved to `storage_entry/userbot-session`, future starts do not require a code and you can run in detached mode with `docker compose up -d`.
+The container stores its runtime files in `/data`. Map a persistent directory on
+the host to this path (for example `~/bot-data:/data`). Because the application
+always writes to `/data`, no `DATA_DIR` environment variable is required.
 
-Logs are available with `docker logs ghost-stories-bot` and additionally stored in the file pointed to by `LOG_FILE`. When `DEBUG_LOG` is enabled, all console output is mirrored to `./data/debug.log` for troubleshooting.
+The compose file sets `stdin_open: true` and `tty: true` so you can enter the SMS code in the terminal on the first run. When the container prints `USERBOT_PHONE_CODE is required for first login!`, type the code you receive from Telegram. After the session is saved to `/data/userbot-session`, future starts do not require a code and you can run in detached mode with `docker compose up -d`.
+
+Logs are available with `docker logs ghost-stories-bot` and additionally stored in the file pointed to by `LOG_FILE`. When `DEBUG_LOG` is enabled, all console output is mirrored to `/data/debug.log` for troubleshooting.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     environment:
       - PUID=568
       - PGID=568
-      - DATA_DIR=/data
-    # This mounts your persistent data directory on the host to the /data
-    # directory inside the container.
+    # Map a directory on the host to /data inside the container.
     volumes:
-      - ./storage_entry:/data
+      - /path/to/storage:/data

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -45,11 +45,9 @@ if (!BTC_WALLET_ADDRESS && !BTC_XPUB && !BTC_YPUB && !BTC_ZPUB) {
   );
 }
 
-// Base directory for all runtime data. Defaults to a `data` folder relative to
-// the project when running locally. The Docker setup passes DATA_DIR=/data so
-// files are stored in the mounted volume.
-export const DATA_DIR =
-  process.env.DATA_DIR || path.resolve(__dirname, '../../data');
+// Base directory for all runtime data inside the container. Docker mounts a
+// persistent host directory here.
+export const DATA_DIR = '/data';
 
 // error log file path
 export const LOG_FILE =

--- a/src/config/userbot.ts
+++ b/src/config/userbot.ts
@@ -2,7 +2,6 @@ import { TelegramClient } from 'telegram';
 import { StoreSession } from 'telegram/sessions';
 import readline from 'readline';
 import path from 'path';
-import { DATA_DIR } from '../db';
 
 import {
   USERBOT_API_HASH,
@@ -60,7 +59,7 @@ export class Userbot {
 
 async function initClient() {
   // Store the userbot session alongside the main database and other data
-  const storeSessionPath = path.resolve(DATA_DIR, 'userbot-session');
+  const storeSessionPath = path.resolve('/data', 'userbot-session');
   const storeSession = new StoreSession(storeSessionPath);
 
   const client = new TelegramClient(

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -6,17 +6,14 @@ import path from 'path';
 import { DownloadQueueItem, UserInfo } from 'types';
 
 /**
- * Base directory where all runtime data is stored. Defaults to a `data` folder
- * relative to the project when running locally. Set the DATA_DIR environment
- * variable (e.g. to `/data` inside the Docker container) to override.
+ * Base directory where all runtime data is stored inside the container.
+ * The Docker compose file mounts a persistent host directory to `/data`.
  */
-export const DATA_DIR =
-  process.env.DATA_DIR || path.resolve(__dirname, '../../data');
+export const DATA_DIR = '/data';
 export const DB_PATH = path.join(DATA_DIR, 'database.db');
 // Ensure the data directory exists before using it
-const dataDir = DATA_DIR;
-if (!fs.existsSync(dataDir)) {
-  fs.mkdirSync(dataDir, { recursive: true });
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
 }
 
 export const db = new SyncDatabase(DB_PATH);

--- a/src/services/admin-stats.ts
+++ b/src/services/admin-stats.ts
@@ -6,10 +6,9 @@ import { db, unblockUser } from '../db';
 
 let startTimestamp = Math.floor(Date.now() / 1000);
 let statusMessageId: number | null = null;
-const BASE_DIR = process.env.DATA_DIR || path.resolve(__dirname, '../../data');
+const BASE_DIR = '/data';
 const STATUS_ID_FILE =
-  process.env.STATUS_ID_FILE ||
-  path.join(BASE_DIR, 'admin_status_id');
+  process.env.STATUS_ID_FILE || path.join(BASE_DIR, 'admin_status_id');
 
 function readSavedStatusId(): number | null {
   try {

--- a/src/services/backup-service.ts
+++ b/src/services/backup-service.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import cron from 'node-cron';
-import { DB_PATH, DATA_DIR } from '../db';
+import { DB_PATH } from '../db';
 
 // Place backups inside the main data directory so all runtime files
 // are grouped together under a single folder.
-const BACKUP_DIR = path.join(DATA_DIR, 'backups');
+const BACKUP_DIR = path.join('/data', 'backups');
 const KEEP_DAYS = 7;
 
 function ensureDir() {

--- a/src/services/session-cleanup-service.ts
+++ b/src/services/session-cleanup-service.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import cron from 'node-cron';
-import { DATA_DIR } from '../db';
 
 // Temporary session files are stored in the same data directory as the
 // database to keep everything contained under a single folder.
@@ -10,10 +9,10 @@ const KEEP_DAYS = 7;
 
 function cleanupOldSessions(): void {
   const cutoff = Date.now() - KEEP_DAYS * 24 * 60 * 60 * 1000;
-  const files = fs.readdirSync(DATA_DIR).filter((f) => f.startsWith(SESSION_PREFIX));
+  const files = fs.readdirSync('/data').filter((f) => f.startsWith(SESSION_PREFIX));
   for (const name of files) {
     try {
-      const file = path.join(DATA_DIR, name);
+      const file = path.join('/data', name);
       const mtime = fs.statSync(file).mtime.getTime();
       if (mtime < cutoff) {
         fs.unlinkSync(file);


### PR DESCRIPTION
## Summary
- drop usage of DATA_DIR environment variable
- store runtime files directly under `/data`
- update documentation and examples accordingly

## Testing
- `yarn install`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6849ea23ff248326b874f457d08082c7