### PR TITLE
Default NODE_ENV to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,6 @@ USERBOT_PASSWORD=
 USERBOT_PHONE_CODE=
 
 BOT_ADMIN_ID=
-
-NODE_ENV=
 # Either a fixed wallet address or an extended public key for deriving unique addresses
 BTC_WALLET_ADDRESS=
 # If one of BTC_XPUB, BTC_YPUB or BTC_ZPUB is set, it overrides BTC_WALLET_ADDRESS and derived addresses will be used

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN yarn build
 # =========================================================================
 # Set up environment and permissions
 # =========================================================================
-ENV NODE_ENV=production
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -7,9 +7,6 @@ module.exports = {
       autorestart: true,
       watch: false,
       max_memory_restart: '1000M',
-      env: {
-        NODE_ENV: 'production',
-      },
     },
   ],
 };

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -12,7 +12,7 @@ const getEnvVar = (key: string): string => {
 };
 
 /** Runtime mode */
-export const NODE_ENV = getEnvVar('NODE_ENV');
+export const NODE_ENV = process.env.NODE_ENV ?? parsed?.NODE_ENV ?? 'production';
 /** Dev mode */
 export const isDevEnv = NODE_ENV === 'development';
 /** Prod mode */


### PR DESCRIPTION
## Summary
- set default `NODE_ENV` to `production` in configuration
- remove `NODE_ENV` from `.env.example`
- stop defining NODE_ENV in Dockerfile and pm2 config

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849fae143c48326919ed2f5f83d683f