### PR TITLE
Disable automatic session cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,6 @@ import {
 } from './services/btc-payment';
 import { getStatusText } from './services/admin-stats';
 import { scheduleDatabaseBackups } from './services/backup-service';
-import { scheduleSessionCleanup } from './services/session-cleanup-service';
 import { handleUpgrade } from 'controllers/upgrade';
 import { handlePremium } from 'controllers/premium';
 import { sendProfileMedia } from 'controllers/send-profile-media';
@@ -1006,7 +1005,7 @@ async function startApp() {
   startMonitorLoop();
   resumePendingChecks();
   scheduleDatabaseBackups();
-  scheduleSessionCleanup();
+  // Session cleanup has been disabled due to potential side effects.
   await bot.telegram.setMyCommands(getBaseCommands('en'));
   await bot.telegram.setMyCommands(
     [...getBaseCommands('en'), ...getPremiumCommands('en'), ...getAdminCommands('en')],


### PR DESCRIPTION
## Summary
- remove call to the session cleanup scheduler

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684a0f7656608326bee4ce949fb706aa