### PR TITLE
Fix missing translation import

### DIFF
--- a/src/controllers/get-stories.ts
+++ b/src/controllers/get-stories.ts
@@ -9,6 +9,7 @@ import { Api } from 'telegram';
 import { FloodWaitError } from 'telegram/errors';
 import { isDevEnv } from 'config/env-config';
 import { notifyAdmin } from 'controllers/send-message';
+import { t } from 'lib/i18n';
 
 
 // =========================================================================


### PR DESCRIPTION
## Summary
- add missing `t` import in `get-stories.ts`

## Testing
- `npm ci --legacy-peer-deps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a8d21e2048326a1e6aa9f6077653c