### PR TITLE
Localize premium info and referral messages

### DIFF
--- a/__tests__/premium-command.test.ts
+++ b/__tests__/premium-command.test.ts
@@ -25,6 +25,7 @@ jest.mock('../src/services/monitor-service', () => ({ MAX_MONITORS_PER_USER: 5 }
 
 import { handlePremium } from '../src/controllers/premium';
 import { IContextBot } from '../src/config/context-interface';
+import { t } from '../src/lib/i18n';
 
 describe('handlePremium', () => {
   test('sends temporary message for existing premium users', async () => {
@@ -32,6 +33,6 @@ describe('handlePremium', () => {
 
     await handlePremium(ctx);
 
-    expect(sendTemporaryMessage).toHaveBeenCalledWith(bot, 1, '✅ You already have Premium access.');
+    expect(sendTemporaryMessage).toHaveBeenCalledWith(bot, 1, t('en', 'premium.already'));
   });
 });

--- a/src/controllers/get-stories.ts
+++ b/src/controllers/get-stories.ts
@@ -9,6 +9,7 @@ import { Api } from 'telegram';
 import { FloodWaitError } from 'telegram/errors';
 import { isDevEnv } from 'config/env-config';
 import { notifyAdmin } from 'controllers/send-message';
+import { t } from 'lib/i18n';
 
 
 // =========================================================================

--- a/src/controllers/premium.ts
+++ b/src/controllers/premium.ts
@@ -3,6 +3,7 @@ import { MAX_MONITORS_PER_USER } from 'services/monitor-service';
 import { isUserPremium } from 'services/premium-service';
 import { sendTemporaryMessage } from 'lib';
 import { bot } from 'index';
+import { t } from 'lib/i18n';
 
 /**
  * Handle the `/premium` command.
@@ -10,18 +11,12 @@ import { bot } from 'index';
  */
 export async function handlePremium(ctx: IContextBot): Promise<void> {
   const userId = String(ctx.from!.id);
+  const locale = ctx.from?.language_code || 'en';
   if (isUserPremium(userId)) {
-    await sendTemporaryMessage(bot, ctx.chat!.id, '✅ You already have Premium access.');
+    await sendTemporaryMessage(bot, ctx.chat!.id, t(locale, 'premium.already'));
     return;
   }
-  await ctx.reply(
-    '🌟 *Premium Access*\n\n' +
-      'Premium users get:\n' +
-      '✅ Unlimited story downloads\n' +
-      `✅ Monitor up to ${MAX_MONITORS_PER_USER} users' active stories\n` +
-      '✅ No cooldowns or waiting in queues\n\n' +
-      'Run `/upgrade` to unlock Premium features.\n' +
-      'You will receive a unique payment address. Invoices expire after one hour.',
-    { parse_mode: 'Markdown' },
-  );
+  await ctx.reply(t(locale, 'premium.info', { limit: MAX_MONITORS_PER_USER }), {
+    parse_mode: 'Markdown',
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ import {
 } from './db';
 import { getRecentHistoryFx } from './db/effects';
 import { processQueue, handleNewTask, getQueueStatusForUser } from './services/queue-manager';
-import { saveUser } from './repositories/user-repository';
+import { saveUser, findUserById } from './repositories/user-repository';
 import {
   isUserPremium,
   addPremiumUser,
@@ -256,7 +256,8 @@ bot.start(async (ctx) => {
       if (total % 5 === 0) {
         extendPremium(inviter, 7);
         try {
-          await ctx.telegram.sendMessage(inviter, t('en', 'referral.fiveUsers'));
+          const inviterLang = findUserById(inviter)?.language;
+          await ctx.telegram.sendMessage(inviter, t(inviterLang, 'referral.fiveUsers'));
         } catch {}
       }
     }
@@ -382,7 +383,8 @@ bot.command('verify', async (ctx) => {
       extendPremium(inviter, daysAdded);
       markReferralPaidRewarded(String(ctx.from.id));
       try {
-        await ctx.telegram.sendMessage(inviter, t('en', 'referral.paid', { days: daysAdded }));
+        const inviterLang = findUserById(inviter)?.language;
+        await ctx.telegram.sendMessage(inviter, t(inviterLang, 'referral.paid', { days: daysAdded }));
       } catch {}
     }
     if (ctx.session?.upgrade && ctx.session.upgrade.invoice.id === invoice.id) {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/ms.json
+++ b/src/locales/ms.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -35,6 +35,7 @@
   "premium.already": "✅ You already have Premium access.",
   "premium.freeTrialUsed": "❌ You have already used your free trial.",
   "premium.freeTrialActivated": "🎉 Free trial activated! You now have Premium access for 7 days.",
+  "premium.info": "🌟 *Premium Access*\n\nPremium users get:\n✅ Unlimited story downloads\n✅ Monitor up to {{limit}} users' active stories\n✅ No cooldowns or waiting in queues\n\nRun `/upgrade` to unlock Premium features.\nYou will receive a unique payment address. Invoices expire after one hour.",
   "verify.usage": "Usage: /verify <txid>",
   "verify.invalidArgs": "Invalid arguments.",
   "verify.wait": "⏳ Please wait {{seconds}}s before verifying again.",


### PR DESCRIPTION
## Summary
- translate `/premium` response via `t()` helper
- notify inviters using their language
- add missing `t` import in story fetching controller
- extend tests for localized premium message

## Testing
- `npm install --legacy-peer-deps`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684a8cb27cac832681f38a7143af9c83