### PR TITLE
Handle timeouts in userbot

### DIFF
--- a/__tests__/userbot-error-handler.test.ts
+++ b/__tests__/userbot-error-handler.test.ts
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../src/config/env-config', () => ({
+  USERBOT_API_HASH: 'h',
+  USERBOT_API_ID: 1,
+  USERBOT_PHONE_NUMBER: '+1',
+  USERBOT_PASSWORD: '',
+  USERBOT_PHONE_CODE: '',
+}));
+
+const recordTimeoutError = jest.fn();
+jest.mock('../src/config/timeout-monitor', () => ({ recordTimeoutError }));
+
+class FakeTelegramClient {
+  session: any = { save: () => '' };
+  async start(opts: any) {
+    if (opts.onError) {
+      opts.onError(new Error('TIMEOUT'));
+    }
+  }
+  async sendMessage() {}
+  async disconnect() {}
+}
+
+jest.mock('telegram', () => ({ TelegramClient: FakeTelegramClient }));
+
+import { initUserbot } from '../src/config/userbot';
+
+test('userbot onError forwards timeout errors', async () => {
+  await initUserbot();
+  expect(recordTimeoutError).toHaveBeenCalledWith(expect.any(Error));
+  expect((recordTimeoutError.mock.calls[0][0] as Error).message).toBe('TIMEOUT');
+});

--- a/src/config/userbot.ts
+++ b/src/config/userbot.ts
@@ -3,6 +3,7 @@ import { StringSession } from 'telegram/sessions';
 import fs from 'fs';
 import readline from 'readline';
 import path from 'path';
+import { recordTimeoutError } from './timeout-monitor';
 
 import {
   USERBOT_API_HASH,
@@ -102,7 +103,10 @@ async function initClient() {
       if (!phoneCode) throw new Error('USERBOT_PHONE_CODE is required for first login!');
       return phoneCode;
     },
-    onError: (err) => console.log('error', err),
+    onError: (err) => {
+      console.log('error', err);
+      recordTimeoutError(err);
+    },
   });
 
   console.log('You should now be connected.');


### PR DESCRIPTION
## Summary
- record timeout errors from Telegram userbot
- test that the error handler forwards TIMEOUT errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b66e8d5308326a5c086efad3d51e1