### PR TITLE
Add healthcheck script to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,8 @@ RUN npm run build
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN chmod +x /usr/local/bin/healthcheck.sh
 RUN chown -R appuser:appgroup /app
 
 # Run the container as the non-root user by default
@@ -66,6 +68,8 @@ USER appuser
 
 # Set our script as the entrypoint for the container.
 ENTRYPOINT ["entrypoint.sh"]
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["/usr/local/bin/healthcheck.sh"]
 
 # =========================================================================
 # Define the default command

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+LOG_FILE=${LOG_FILE:-/data/error.log}
+# Fail if the main node process is not running
+if ! pgrep -f "dist/index.js" > /dev/null; then
+  exit 1
+fi
+# Fail if recent logs show timeout monitor exit
+if [ -f "$LOG_FILE" ] && tail -n 20 "$LOG_FILE" | grep -q "TimeoutMonitor"; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- add a shell health check that looks for TimeoutMonitor messages
- copy healthcheck into the Docker image and register via HEALTHCHECK

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c38fa1da88326bc07a20f77512a61