### PR TITLE
Improve auto-restart on connection errors

### DIFF
--- a/__tests__/userbot-error-handler.test.ts
+++ b/__tests__/userbot-error-handler.test.ts
@@ -16,6 +16,7 @@ class FakeTelegramClient {
   async start(opts: any) {
     if (opts.onError) {
       opts.onError(new Error('TIMEOUT'));
+      opts.onError(new Error('Not connected'));
     }
   }
   async sendMessage() {}
@@ -28,6 +29,7 @@ import { initUserbot } from '../src/config/userbot';
 
 test('userbot onError forwards timeout errors', async () => {
   await initUserbot();
-  expect(recordTimeoutError).toHaveBeenCalledWith(expect.any(Error));
+  expect(recordTimeoutError).toHaveBeenCalledTimes(2);
   expect((recordTimeoutError.mock.calls[0][0] as Error).message).toBe('TIMEOUT');
+  expect((recordTimeoutError.mock.calls[1][0] as Error).message).toBe('Not connected');
 });

--- a/src/config/timeout-monitor.ts
+++ b/src/config/timeout-monitor.ts
@@ -1,17 +1,18 @@
 export const MAX_TIMEOUT_ERRORS = 10;
 export const TIME_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
-let timeouts: number[] = [];
+let errorTimestamps: number[] = [];
 
 export function recordTimeoutError(err: unknown): void {
   const msg = typeof err === 'string' ? err : (err as any)?.message;
   if (typeof msg !== 'string') return;
-  if (!msg.toUpperCase().includes('TIMEOUT')) return;
+  const upper = msg.toUpperCase();
+  if (!upper.includes('TIMEOUT') && !upper.includes('NOT CONNECTED')) return;
   const now = Date.now();
-  timeouts.push(now);
-  timeouts = timeouts.filter(t => now - t < TIME_WINDOW_MS);
-  if (timeouts.length >= MAX_TIMEOUT_ERRORS) {
+  errorTimestamps.push(now);
+  errorTimestamps = errorTimestamps.filter(t => now - t < TIME_WINDOW_MS);
+  if (errorTimestamps.length >= MAX_TIMEOUT_ERRORS) {
     console.error(
-      `[TimeoutMonitor] Exiting after ${timeouts.length} TIMEOUT errors within ${TIME_WINDOW_MS / 1000} seconds.`
+      `[TimeoutMonitor] Exiting after ${errorTimestamps.length} connection errors within ${TIME_WINDOW_MS / 1000} seconds.`
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- broaden timeout monitor to catch "Not connected" errors
- expand userbot error handler test

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ced732f148326a4014d2bdfd5955a