### PR TITLE
hotfix: stop Telegram command-menu flood outage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,4 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["/usr/local/bin/healthc
 # =========================================================================
 # Define the default command
 # =========================================================================
-CMD ["node", "dist/index.js"]
+CMD ["node", "--require", "./command-menu-flood-guard.js", "dist/index.js"]

--- a/__tests__/command-menu-flood-guard.test.ts
+++ b/__tests__/command-menu-flood-guard.test.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+
+describe('command menu flood guard', () => {
+  test('suppresses only command-menu API calls', async () => {
+    jest.resetModules();
+    const telegraf = require('telegraf');
+    const originalCallApi = jest.fn().mockResolvedValue({ ok: true });
+    telegraf.Telegram.prototype.callApi = originalCallApi;
+
+    require('../command-menu-flood-guard.js');
+
+    const telegram = new telegraf.Telegram('test-token');
+    await telegram.callApi('setMyCommands', { commands: [] });
+    await telegram.callApi('deleteMyCommands', {});
+
+    expect(originalCallApi).not.toHaveBeenCalled();
+
+    const payload = { chat_id: 123, text: 'alive' };
+    await telegram.callApi('sendMessage', payload);
+
+    expect(originalCallApi).toHaveBeenCalledTimes(1);
+    expect(originalCallApi).toHaveBeenCalledWith('sendMessage', payload, undefined);
+  });
+
+  test('production entrypoints preload the guard', () => {
+    const ecosystem = fs.readFileSync('ecosystem.config.js', 'utf8');
+    const dockerfile = fs.readFileSync('Dockerfile', 'utf8');
+
+    expect(ecosystem).toContain('--require ./command-menu-flood-guard.js');
+    expect(dockerfile).toContain(
+      'CMD ["node", "--require", "./command-menu-flood-guard.js", "dist/index.js"]',
+    );
+  });
+});

--- a/command-menu-flood-guard.js
+++ b/command-menu-flood-guard.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Emergency production guard for Telegram command-menu API floods.
+ *
+ * PR #310 introduced eager command-scope synchronization across historical
+ * users and on live updates. Telegram rate-limits setMyCommands and
+ * deleteMyCommands globally for the bot token; once that flood limit is hit,
+ * normal sendMessage replies can also be delayed or rejected.
+ *
+ * This preload suppresses only command-menu maintenance calls. Polling,
+ * messages, callbacks, invoices, payments, and all command handlers continue
+ * through Telegraf unchanged. Remove this guard after command-menu sync is
+ * redesigned as a bounded background job.
+ */
+const { Telegram } = require('telegraf');
+
+const PATCHED = Symbol.for('telegram-stories.command-menu-flood-guard');
+const SUPPRESSED_METHODS = new Set(['setMyCommands', 'deleteMyCommands']);
+
+if (!Telegram.prototype[PATCHED]) {
+  const originalCallApi = Telegram.prototype.callApi;
+  let warned = false;
+
+  Telegram.prototype.callApi = function guardedCallApi(method, payload, signal) {
+    if (SUPPRESSED_METHODS.has(method)) {
+      if (!warned) {
+        warned = true;
+        console.warn(
+          '[CommandMenuGuard] Suppressing Telegram command-menu API calls to prevent flood limits.',
+        );
+      }
+      return Promise.resolve(true);
+    }
+
+    return originalCallApi.call(this, method, payload, signal);
+  };
+
+  Object.defineProperty(Telegram.prototype, PATCHED, {
+    value: true,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+}

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,6 +3,7 @@ module.exports = {
     {
       name: 'telegram-stories-bot',
       script: './dist/index.js',
+      node_args: '--require ./command-menu-flood-guard.js',
       instances: 1,
       autorestart: true,
       watch: false,


### PR DESCRIPTION
## Incident

After PR #310 reached production, the bot began hitting Telegram flood limits and stopped replying to commands even though polling appeared to start.

## Root cause

The new command-scope migration performs `setMyCommands` and `deleteMyCommands` across historical users and groups, then retries unsuccessful scope writes from live update processing. On a production-sized database this can exhaust the bot token's Telegram API allowance and interfere with ordinary `sendMessage` replies.

## Emergency fix

- preload a narrow Telegraf API guard in both Docker and PM2 deployments
- suppress only `setMyCommands` and `deleteMyCommands`
- preserve polling, command handlers, messages, callbacks, invoices, payments, media delivery, and all other Telegram methods
- add a behavioral test proving normal API calls still pass through

This is deliberately a circuit breaker. Command-menu maintenance should be redesigned as bounded background work before the guard is removed.

## Deployment note

Rebuild/redeploy and restart the bot after merging. Existing Telegram flood limits may require their server-provided retry interval to expire, but the bot will stop generating new command-menu flood traffic immediately.